### PR TITLE
fix: validate IBAN and accept Czech BBAN input

### DIFF
--- a/src/core/background-jobs/jobs/fio-account-transaction-sync-job.test.ts
+++ b/src/core/background-jobs/jobs/fio-account-transaction-sync-job.test.ts
@@ -159,14 +159,14 @@ describe("fio account transaction sync job", () => {
     expect(requestedUrls).toEqual([
       "https://fioapi.fio.cz/v1/rest/periods/fio-token-1/2026-03-31/2026-05-31/transactions.json",
     ])
-    expect(
-      await evolu.loadQuery(fioPluginSyncPointerQuery(fioPluginId))
-    ).toEqual([
-      {
-        id: fioPluginId,
-        lastSyncedDate: "2026-05-31",
-      },
-    ])
+    await expect
+      .poll(() => evolu.loadQuery(fioPluginSyncPointerQuery(fioPluginId)))
+      .toEqual([
+        {
+          id: fioPluginId,
+          lastSyncedDate: "2026-05-31",
+        },
+      ])
     expect(errors).toEqual([])
   })
 

--- a/src/core/background-jobs/jobs/fio-account-transaction-sync-job.test.ts
+++ b/src/core/background-jobs/jobs/fio-account-transaction-sync-job.test.ts
@@ -396,7 +396,7 @@ describe("fio account transaction sync job", () => {
       },
       fetch: async () =>
         statementResponse({
-          iban: "CZ2408000000001234567899",
+          iban: "CZ5508000000001234567899",
           transactions: [fioTransaction],
         }),
       date: {

--- a/src/core/modules/account-transaction/account-transaction-actions.test.ts
+++ b/src/core/modules/account-transaction/account-transaction-actions.test.ts
@@ -337,7 +337,7 @@ describe("account transaction actions", () => {
         deviceId: null,
         name: "Second bank account",
         iban: {
-          iban: "CZ2408000000001234567899",
+          iban: "CZ5508000000001234567899",
           currency: "CZK",
         },
       })

--- a/src/core/modules/shared/iban-utils.test.ts
+++ b/src/core/modules/shared/iban-utils.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, test } from "vitest"
 import {
+  BbanSchema,
+  czechBbanToIban,
   normalizeBankAccountInputToIban,
   normalizeIbanInput,
 } from "./iban-utils.ts"
-import { IbanSchema } from "./schema.ts"
+import { BankAccountInputIbanSchema, IbanSchema } from "./schema.ts"
 
 describe("IBAN utilities", () => {
   test("normalizes IBAN spacing and case", () => {
@@ -18,6 +20,12 @@ describe("IBAN utilities", () => {
     )
   })
 
+  test("normalizes bank account input schema output", () => {
+    expect(BankAccountInputIbanSchema.parse("123456789/0100")).toBe(
+      "CZ1801000000000123456789"
+    )
+  })
+
   test("validates IBAN checksum and country length", () => {
     expect(IbanSchema.safeParse("CZ6508000000192000145399").success).toBe(true)
     expect(IbanSchema.safeParse("CZ6508000000192000145398").success).toBe(false)
@@ -26,26 +34,45 @@ describe("IBAN utilities", () => {
     )
   })
 
+  test("normalizes Czech BBAN schema output", () => {
+    expect(BbanSchema.parse("123-12345678/0100")).toBe("01000001230012345678")
+    expect(BbanSchema.parse(" 123456789 / 0100 ")).toBe("01000000000123456789")
+  })
+
+  test("rejects invalid Czech BBAN schema input", () => {
+    expect(BbanSchema.safeParse("/0100").success).toBe(false)
+    expect(BbanSchema.safeParse("123456789/").success).toBe(false)
+    expect(BbanSchema.safeParse("123456789/01000").success).toBe(false)
+  })
+
+  test("converts Czech BBAN type to normalized IBAN", () => {
+    expect(czechBbanToIban(BbanSchema.parse("123456789/0100"))).toBe(
+      "CZ1801000000000123456789"
+    )
+  })
+
   test("converts Czech BBAN without prefix to normalized IBAN", () => {
     expect(normalizeBankAccountInputToIban("123456789/0100")).toEqual({
-      success: true,
-      iban: "CZ1801000000000123456789",
+      ok: true,
+      value: "CZ1801000000000123456789",
     })
   })
 
   test("converts Czech BBAN with prefix to normalized IBAN", () => {
     expect(normalizeBankAccountInputToIban("123-12345678/0100")).toEqual({
-      success: true,
-      iban: "CZ5701000001230012345678",
+      ok: true,
+      value: "CZ5701000001230012345678",
     })
   })
 
   test("rejects BBAN with missing account number or bank code", () => {
     expect(normalizeBankAccountInputToIban("/0100")).toEqual({
-      success: false,
+      ok: false,
+      error: { type: "InvalidBankAccountInput" },
     })
     expect(normalizeBankAccountInputToIban("123456789/")).toEqual({
-      success: false,
+      ok: false,
+      error: { type: "InvalidBankAccountInput" },
     })
   })
 })

--- a/src/core/modules/shared/iban-utils.test.ts
+++ b/src/core/modules/shared/iban-utils.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, test } from "vitest"
+import {
+  normalizeBankAccountInputToIban,
+  normalizeIbanInput,
+} from "./iban-utils.ts"
+import { IbanSchema } from "./schema.ts"
+
+describe("IBAN utilities", () => {
+  test("normalizes IBAN spacing and case", () => {
+    expect(normalizeIbanInput(" cz65 0800 0000 1920 0014 5399 ")).toBe(
+      "CZ6508000000192000145399"
+    )
+  })
+
+  test("normalizes valid IBAN schema output", () => {
+    expect(IbanSchema.parse(" cz65 0800 0000 1920 0014 5399 ")).toBe(
+      "CZ6508000000192000145399"
+    )
+  })
+
+  test("validates IBAN checksum and country length", () => {
+    expect(IbanSchema.safeParse("CZ6508000000192000145399").success).toBe(true)
+    expect(IbanSchema.safeParse("CZ6508000000192000145398").success).toBe(false)
+    expect(IbanSchema.safeParse("CZ650800000019200014539999").success).toBe(
+      false
+    )
+  })
+
+  test("converts Czech BBAN without prefix to normalized IBAN", () => {
+    expect(normalizeBankAccountInputToIban("123456789/0100")).toEqual({
+      success: true,
+      iban: "CZ1801000000000123456789",
+    })
+  })
+
+  test("converts Czech BBAN with prefix to normalized IBAN", () => {
+    expect(normalizeBankAccountInputToIban("123-12345678/0100")).toEqual({
+      success: true,
+      iban: "CZ5701000001230012345678",
+    })
+  })
+
+  test("rejects BBAN with missing account number or bank code", () => {
+    expect(normalizeBankAccountInputToIban("/0100")).toEqual({
+      success: false,
+    })
+    expect(normalizeBankAccountInputToIban("123456789/")).toEqual({
+      success: false,
+    })
+  })
+})

--- a/src/core/modules/shared/iban-utils.ts
+++ b/src/core/modules/shared/iban-utils.ts
@@ -1,0 +1,170 @@
+const ibanCountryLengths: Readonly<Record<string, number>> = {
+  AD: 24,
+  AE: 23,
+  AL: 28,
+  AT: 20,
+  AZ: 28,
+  BA: 20,
+  BE: 16,
+  BG: 22,
+  BH: 22,
+  BR: 29,
+  BY: 28,
+  CH: 21,
+  CR: 22,
+  CY: 28,
+  CZ: 24,
+  DE: 22,
+  DK: 18,
+  DO: 28,
+  EE: 20,
+  EG: 29,
+  ES: 24,
+  FI: 18,
+  FO: 18,
+  FR: 27,
+  GB: 22,
+  GE: 22,
+  GI: 23,
+  GL: 18,
+  GR: 27,
+  GT: 28,
+  HR: 21,
+  HU: 28,
+  IE: 22,
+  IL: 23,
+  IQ: 23,
+  IS: 26,
+  IT: 27,
+  JO: 30,
+  KW: 30,
+  KZ: 20,
+  LB: 28,
+  LC: 32,
+  LI: 21,
+  LT: 20,
+  LU: 20,
+  LV: 21,
+  MC: 27,
+  MD: 24,
+  ME: 22,
+  MK: 19,
+  MR: 27,
+  MT: 31,
+  MU: 30,
+  NL: 18,
+  NO: 15,
+  PK: 24,
+  PL: 28,
+  PS: 29,
+  PT: 25,
+  QA: 29,
+  RO: 24,
+  RS: 22,
+  SA: 24,
+  SC: 31,
+  SE: 24,
+  SI: 19,
+  SK: 24,
+  SM: 27,
+  ST: 25,
+  SV: 28,
+  TL: 23,
+  TN: 24,
+  TR: 26,
+  UA: 29,
+  VA: 22,
+  VG: 24,
+  XK: 20,
+} as const
+
+const czechBbanPattern = /^(?:(\d{1,6})-)?(\d{1,10})\/(\d{4})$/u
+
+export interface NormalizedBankAccountInput {
+  readonly success: true
+  readonly iban: string
+}
+
+export interface InvalidBankAccountInput {
+  readonly success: false
+}
+
+export type BankAccountInputResult =
+  | NormalizedBankAccountInput
+  | InvalidBankAccountInput
+
+export const normalizeIbanInput = (value: string) =>
+  value.replaceAll(/\s/gu, "").toUpperCase()
+
+const getIbanRemainder = (value: string) => {
+  let remainder = 0
+
+  for (const char of value) {
+    const charCode = char.charCodeAt(0)
+    const digits =
+      charCode >= 65 && charCode <= 90 ? String(charCode - 55) : char
+
+    for (const digit of digits) {
+      remainder = (remainder * 10 + Number(digit)) % 97
+    }
+  }
+
+  return remainder
+}
+
+export const isValidIban = (value: string) => {
+  const iban = normalizeIbanInput(value)
+
+  if (!/^[A-Z]{2}\d{2}[A-Z0-9]{1,30}$/u.test(iban)) {
+    return false
+  }
+
+  const expectedLength = ibanCountryLengths[iban.slice(0, 2)]
+
+  if (expectedLength === undefined || iban.length !== expectedLength) {
+    return false
+  }
+
+  return getIbanRemainder(`${iban.slice(4)}${iban.slice(0, 4)}`) === 1
+}
+
+const createIbanFromCountryAndBban = (countryCode: string, bban: string) => {
+  const checkDigits = 98 - getIbanRemainder(`${bban}${countryCode}00`)
+  return `${countryCode}${String(checkDigits).padStart(2, "0")}${bban}`
+}
+
+export const czechBbanToIban = (value: string) => {
+  const normalizedValue = value.replaceAll(/\s/gu, "")
+  const match = czechBbanPattern.exec(normalizedValue)
+
+  if (!match) {
+    return null
+  }
+
+  const [, prefix = "", accountNumber, bankCode] = match
+
+  if (accountNumber === undefined || bankCode === undefined) {
+    return null
+  }
+
+  const bban = `${bankCode}${prefix.padStart(6, "0")}${accountNumber.padStart(10, "0")}`
+  return createIbanFromCountryAndBban("CZ", bban)
+}
+
+export const normalizeBankAccountInputToIban = (
+  value: string
+): BankAccountInputResult => {
+  const iban = normalizeIbanInput(value)
+
+  if (isValidIban(iban)) {
+    return { success: true, iban }
+  }
+
+  const czechIban = czechBbanToIban(value)
+
+  if (czechIban && isValidIban(czechIban)) {
+    return { success: true, iban: czechIban }
+  }
+
+  return { success: false }
+}

--- a/src/core/modules/shared/iban-utils.ts
+++ b/src/core/modules/shared/iban-utils.ts
@@ -1,3 +1,6 @@
+import { err, ok, type Result } from "@evolu/common"
+import { z } from "zod"
+
 const ibanCountryLengths: Readonly<Record<string, number>> = {
   AD: 24,
   AE: 23,
@@ -80,18 +83,18 @@ const ibanCountryLengths: Readonly<Record<string, number>> = {
 
 const czechBbanPattern = /^(?:(\d{1,6})-)?(\d{1,10})\/(\d{4})$/u
 
-export interface NormalizedBankAccountInput {
-  readonly success: true
-  readonly iban: string
+export interface InvalidBankAccountInputError {
+  readonly type: "InvalidBankAccountInput"
 }
 
-export interface InvalidBankAccountInput {
-  readonly success: false
-}
+export type BankAccountInputResult = Result<
+  string,
+  InvalidBankAccountInputError
+>
 
-export type BankAccountInputResult =
-  | NormalizedBankAccountInput
-  | InvalidBankAccountInput
+export const invalidBankAccountInput = (): InvalidBankAccountInputError => ({
+  type: "InvalidBankAccountInput",
+})
 
 export const normalizeIbanInput = (value: string) =>
   value.replaceAll(/\s/gu, "").toUpperCase()
@@ -133,7 +136,7 @@ const createIbanFromCountryAndBban = (countryCode: string, bban: string) => {
   return `${countryCode}${String(checkDigits).padStart(2, "0")}${bban}`
 }
 
-export const czechBbanToIban = (value: string) => {
+export const normalizeCzechBbanInput = (value: string) => {
   const normalizedValue = value.replaceAll(/\s/gu, "")
   const match = czechBbanPattern.exec(normalizedValue)
 
@@ -147,7 +150,29 @@ export const czechBbanToIban = (value: string) => {
     return null
   }
 
-  const bban = `${bankCode}${prefix.padStart(6, "0")}${accountNumber.padStart(10, "0")}`
+  return `${bankCode}${prefix.padStart(6, "0")}${accountNumber.padStart(10, "0")}`
+}
+
+export const BbanSchema = z
+  .string()
+  .transform((value, context) => {
+    const bban = normalizeCzechBbanInput(value)
+
+    if (bban === null) {
+      context.addIssue({
+        code: "custom",
+        message: "Invalid BBAN.",
+      })
+
+      return z.NEVER
+    }
+
+    return bban
+  })
+  .brand<"Bban">()
+export type Bban = z.output<typeof BbanSchema>
+
+export const czechBbanToIban = (bban: Bban) => {
   return createIbanFromCountryAndBban("CZ", bban)
 }
 
@@ -157,14 +182,15 @@ export const normalizeBankAccountInputToIban = (
   const iban = normalizeIbanInput(value)
 
   if (isValidIban(iban)) {
-    return { success: true, iban }
+    return ok(iban)
   }
 
-  const czechIban = czechBbanToIban(value)
+  const bban = BbanSchema.safeParse(value)
+  const czechIban = bban.success ? czechBbanToIban(bban.data) : null
 
   if (czechIban && isValidIban(czechIban)) {
-    return { success: true, iban: czechIban }
+    return ok(czechIban)
   }
 
-  return { success: false }
+  return err(invalidBankAccountInput())
 }

--- a/src/core/modules/shared/schema.ts
+++ b/src/core/modules/shared/schema.ts
@@ -1,7 +1,11 @@
 import type { StandardSchemaV1 } from "@evolu/common"
 import { z } from "zod"
 
-import { isValidIban, normalizeIbanInput } from "./iban-utils.ts"
+import {
+  isValidIban,
+  normalizeBankAccountInputToIban,
+  normalizeIbanInput,
+} from "./iban-utils.ts"
 
 export type InferTable<T extends Readonly<Record<string, StandardSchemaV1>>> =
   Readonly<{
@@ -163,6 +167,23 @@ export const IbanSchema = z
   .transform(normalizeIbanInput)
   .refine(isValidIban)
   .brand<"Iban">()
+export type Iban = z.output<typeof IbanSchema>
+export const BankAccountInputIbanSchema = z
+  .string()
+  .transform((value, context) => {
+    const result = normalizeBankAccountInputToIban(value)
+
+    if (!result.ok) {
+      context.addIssue({
+        code: "custom",
+        message: "Invalid bank account input.",
+      })
+
+      return z.NEVER
+    }
+
+    return result.value as Iban
+  })
 export const VariableSymbolSchema = z
   .string()
   .trim()
@@ -189,6 +210,5 @@ export type ItemLineType = z.output<typeof ItemLineTypeSchema>
 export type BillLineTag = z.output<typeof BillLineTagSchema>
 export type Integer = z.output<typeof IntegerSchema>
 export type FloatString = z.output<typeof NumberStringSchema>
-export type Iban = z.output<typeof IbanSchema>
 export type VariableSymbol = z.output<typeof VariableSymbolSchema>
 export type ConstantSymbol = z.output<typeof ConstantSymbolSchema>

--- a/src/core/modules/shared/schema.ts
+++ b/src/core/modules/shared/schema.ts
@@ -1,6 +1,8 @@
 import type { StandardSchemaV1 } from "@evolu/common"
 import { z } from "zod"
 
+import { isValidIban, normalizeIbanInput } from "./iban-utils.ts"
+
 export type InferTable<T extends Readonly<Record<string, StandardSchemaV1>>> =
   Readonly<{
     [K in keyof T]: StandardSchemaV1.InferOutput<T[K]>
@@ -158,8 +160,8 @@ export const ItemLineTypeSchema = z.enum(["catalogItem", "manualAmount", "tip"])
 export const BillLineTagSchema = z.enum(["add", "remove"])
 export const IbanSchema = z
   .string()
-  .trim()
-  .regex(/^[A-Z]{2}\d{2}[A-Z0-9]{1,30}$/u)
+  .transform(normalizeIbanInput)
+  .refine(isValidIban)
   .brand<"Iban">()
 export const VariableSymbolSchema = z
   .string()

--- a/src/i18n/resources.ts
+++ b/src/i18n/resources.ts
@@ -335,11 +335,12 @@ export const resources = {
       "This app currently uses one deterministic fiat bank account.",
     "settings.fiatBankAccount.form.title": "Bank account details",
     "settings.fiatBankAccount.iban.description":
-      "Spaces are removed before saving.",
-    "settings.fiatBankAccount.iban.invalid": "Enter a valid IBAN.",
-    "settings.fiatBankAccount.iban.label": "IBAN",
+      "Enter an IBAN or a Czech account number such as 123456789/0100. The saved value is normalized to IBAN.",
+    "settings.fiatBankAccount.iban.invalid":
+      "Enter a valid IBAN or Czech account number.",
+    "settings.fiatBankAccount.iban.label": "IBAN or account number",
     "settings.fiatBankAccount.iban.required":
-      "IBAN is required when the bank account is enabled.",
+      "IBAN or account number is required when the bank account is enabled.",
     "settings.fiatBankAccount.qrFormat.description":
       "This format is shown first for bank QR payments.",
     "settings.fiatBankAccount.qrFormat.label": "Default QR format",
@@ -897,11 +898,12 @@ export const resources = {
       "Aplikace teď používá jeden deterministický fiat bankovní účet.",
     "settings.fiatBankAccount.form.title": "Údaje bankovního účtu",
     "settings.fiatBankAccount.iban.description":
-      "Mezery se před uložením odstraní.",
-    "settings.fiatBankAccount.iban.invalid": "Zadejte platný IBAN.",
-    "settings.fiatBankAccount.iban.label": "IBAN",
+      "Zadejte IBAN nebo české číslo účtu, například 123456789/0100. Uložená hodnota se normalizuje na IBAN.",
+    "settings.fiatBankAccount.iban.invalid":
+      "Zadejte platný IBAN nebo české číslo účtu.",
+    "settings.fiatBankAccount.iban.label": "IBAN nebo číslo účtu",
     "settings.fiatBankAccount.iban.required":
-      "IBAN je povinný, když je bankovní účet povolený.",
+      "IBAN nebo číslo účtu je povinné, když je bankovní účet povolený.",
     "settings.fiatBankAccount.qrFormat.description":
       "Tento formát se u bankovních QR plateb zobrazí jako první.",
     "settings.fiatBankAccount.qrFormat.label": "Výchozí formát QR",
@@ -1460,11 +1462,12 @@ export const resources = {
       "Aplikácia teraz používa jeden deterministický fiat bankový účet.",
     "settings.fiatBankAccount.form.title": "Údaje bankového účtu",
     "settings.fiatBankAccount.iban.description":
-      "Medzery sa pred uložením odstránia.",
-    "settings.fiatBankAccount.iban.invalid": "Zadajte platný IBAN.",
-    "settings.fiatBankAccount.iban.label": "IBAN",
+      "Zadajte IBAN alebo české číslo účtu, napríklad 123456789/0100. Uložená hodnota sa normalizuje na IBAN.",
+    "settings.fiatBankAccount.iban.invalid":
+      "Zadajte platný IBAN alebo české číslo účtu.",
+    "settings.fiatBankAccount.iban.label": "IBAN alebo číslo účtu",
     "settings.fiatBankAccount.iban.required":
-      "IBAN je povinný, keď je bankový účet povolený.",
+      "IBAN alebo číslo účtu je povinné, keď je bankový účet povolený.",
     "settings.fiatBankAccount.qrFormat.description":
       "Tento formát sa pri bankových QR platbách zobrazí ako prvý.",
     "settings.fiatBankAccount.qrFormat.label": "Predvolený formát QR",

--- a/src/routes/_terminal.settings.payment-accounts.tsx
+++ b/src/routes/_terminal.settings.payment-accounts.tsx
@@ -39,6 +39,7 @@ import {
   bankQrFormats,
   isBankQrFormat,
 } from "@/core/modules/payment/payment-iban-qr-payload-utils.ts"
+import { normalizeBankAccountInputToIban } from "@/core/modules/shared/iban-utils.ts"
 import {
   type BankQrFormat,
   FiatCurrency,
@@ -61,9 +62,6 @@ export const Route = createFileRoute("/_terminal/settings/payment-accounts")({
     },
   },
 })
-
-const normalizeIban = (value: string) =>
-  value.replaceAll(/\s/gu, "").toUpperCase()
 
 const normalizeMnemonic = (value: string) =>
   value.trim().replaceAll(/\s+/gu, " ")
@@ -150,9 +148,12 @@ function FiatBankAccountForm() {
         setError(null)
         setSaved(false)
 
-        const normalizedIban = normalizeIban(iban)
-        const ibanResult = normalizedIban
-          ? IbanSchema.safeParse(normalizedIban)
+        const trimmedBankAccount = iban.trim()
+        const bankAccountResult = trimmedBankAccount
+          ? normalizeBankAccountInputToIban(trimmedBankAccount)
+          : null
+        const ibanResult = bankAccountResult?.success
+          ? IbanSchema.safeParse(bankAccountResult.iban)
           : null
 
         if (enabled && !ibanResult) {
@@ -160,7 +161,10 @@ function FiatBankAccountForm() {
           return
         }
 
-        if (ibanResult?.success === false) {
+        if (
+          ibanResult?.success === false ||
+          bankAccountResult?.success === false
+        ) {
           setError("settings.fiatBankAccount.iban.invalid")
           return
         }
@@ -182,7 +186,7 @@ function FiatBankAccountForm() {
             })
           )
 
-          setIban(normalizedIban)
+          setIban(ibanResult?.data ?? "")
           setSaved(true)
         } finally {
           setPending(false)

--- a/src/routes/_terminal.settings.payment-accounts.tsx
+++ b/src/routes/_terminal.settings.payment-accounts.tsx
@@ -39,12 +39,11 @@ import {
   bankQrFormats,
   isBankQrFormat,
 } from "@/core/modules/payment/payment-iban-qr-payload-utils.ts"
-import { normalizeBankAccountInputToIban } from "@/core/modules/shared/iban-utils.ts"
 import {
+  BankAccountInputIbanSchema,
   type BankQrFormat,
   FiatCurrency,
   type FiatCurrency as FiatCurrencyType,
-  IbanSchema,
   NonEmptyString255Schema,
 } from "@/core/modules/shared/schema.ts"
 import { createDefaultSparkPaymentWallet } from "@/core/spark/spark-wallet.ts"
@@ -148,23 +147,15 @@ function FiatBankAccountForm() {
         setError(null)
         setSaved(false)
 
-        const trimmedBankAccount = iban.trim()
-        const bankAccountResult = trimmedBankAccount
-          ? normalizeBankAccountInputToIban(trimmedBankAccount)
-          : null
-        const ibanResult = bankAccountResult?.success
-          ? IbanSchema.safeParse(bankAccountResult.iban)
-          : null
+        const ibanResult =
+          iban === "" ? null : BankAccountInputIbanSchema.safeParse(iban)
 
         if (enabled && !ibanResult) {
           setError("settings.fiatBankAccount.iban.required")
           return
         }
 
-        if (
-          ibanResult?.success === false ||
-          bankAccountResult?.success === false
-        ) {
+        if (ibanResult?.success === false) {
           setError("settings.fiatBankAccount.iban.invalid")
           return
         }

--- a/src/routes/onboarding.tsx
+++ b/src/routes/onboarding.tsx
@@ -44,9 +44,9 @@ import { updateSettings } from "@/core/modules/app-settings/app-settings-actions
 import { settingsQuery } from "@/core/modules/app-settings/app-settings-queries.ts"
 import type { DefaultPaymentMethod } from "@/core/modules/app-settings/app-settings-types.ts"
 import {
+  BankAccountInputIbanSchema,
   FiatCurrency,
   type FiatCurrency as FiatCurrencyType,
-  IbanSchema,
 } from "@/core/modules/shared/schema.ts"
 import { useConsole } from "@/hooks/use-console.ts"
 import { useEvolu } from "@/hooks/use-evolu.ts"
@@ -132,14 +132,14 @@ const paymentMethodOptions: ReadonlyArray<PaymentMethodOption> = [
 
 const currencyOptions: ReadonlyArray<CurrencyOption> = [
   {
-    value: FiatCurrency.EUR,
-    label: "settings.fiat.eur.title",
-    description: "settings.fiat.eur.description",
-  },
-  {
     value: FiatCurrency.USD,
     label: "settings.fiat.usd.title",
     description: "settings.fiat.usd.description",
+  },
+  {
+    value: FiatCurrency.EUR,
+    label: "settings.fiat.eur.title",
+    description: "settings.fiat.eur.description",
   },
   {
     value: FiatCurrency.CZK,
@@ -147,9 +147,6 @@ const currencyOptions: ReadonlyArray<CurrencyOption> = [
     description: "settings.fiat.czk.description",
   },
 ]
-
-const normalizeIban = (value: string) =>
-  value.replaceAll(/\s/gu, "").toUpperCase()
 
 const getStepIndex = (step: OnboardingStep) => steps.indexOf(step)
 
@@ -228,10 +225,8 @@ function OnboardingPage() {
     setIbanError(null)
 
     const ibanEnabled = selectedPaymentMethods.has("iban")
-    const normalizedIban = normalizeIban(iban)
-    const ibanResult = normalizedIban
-      ? IbanSchema.safeParse(normalizedIban)
-      : null
+    const ibanResult =
+      iban === "" ? null : BankAccountInputIbanSchema.safeParse(iban)
 
     if (ibanEnabled && !ibanResult) {
       setIbanError("settings.fiatBankAccount.iban.required")


### PR DESCRIPTION
## Summary
- add IBAN country length and checksum validation with normalized schema output
- accept Czech BBAN account numbers in payment account settings and convert them to IBAN before saving
- update payment account helper text and validation errors in EN/CS/SK

Closes #12

## Test Plan
- bun vitest run src/core/modules/shared/iban-utils.test.ts
- bun run check:lint
- bun run check:ts
- bun run build

## Notes
- Full bun run check currently reaches check:tests and fails on pre-existing runtime environment issues unrelated to this change: Promise.try is not a function and AsyncDisposableStack is not defined across existing task/Evolu tests.