### PR TITLE
fix: polyfill Vitest runtime globals

### DIFF
--- a/src/polyfills/core-js.d.ts
+++ b/src/polyfills/core-js.d.ts
@@ -1,1 +1,2 @@
 declare module "core-js/proposals/explicit-resource-management" {}
+declare module "core-js/proposals/promise-try" {}

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,0 +1,98 @@
+import "core-js/proposals/explicit-resource-management"
+import "core-js/proposals/promise-try"
+
+type TestLockCallback = (lock: Lock | null) => unknown | PromiseLike<unknown>
+
+interface TestLockRequest {
+  readonly name: string
+  readonly callback: TestLockCallback
+  readonly options: LockOptions
+  readonly resolve: (value: unknown) => void
+  readonly reject: (reason?: unknown) => void
+}
+
+class TestLockManager implements LockManager {
+  #held = new Set<string>()
+  #pending: TestLockRequest[] = []
+
+  request(
+    name: string,
+    optionsOrCallback: LockOptions | LockGrantedCallback<unknown>,
+    maybeCallback?: LockGrantedCallback<unknown>
+  ): Promise<unknown> {
+    const options =
+      typeof optionsOrCallback === "function" ? {} : optionsOrCallback
+    const callback =
+      typeof optionsOrCallback === "function"
+        ? optionsOrCallback
+        : maybeCallback
+
+    if (callback === undefined) {
+      return Promise.reject(new TypeError("Lock callback is required."))
+    }
+
+    if (options.ifAvailable === true && this.#held.has(name)) {
+      return Promise.resolve(callback(null))
+    }
+
+    return new Promise((resolve, reject) => {
+      const request = { name, callback, options, resolve, reject }
+      this.#pending.push(request)
+
+      options.signal?.addEventListener(
+        "abort",
+        () => {
+          this.#pending = this.#pending.filter((item) => item !== request)
+          reject(options.signal?.reason)
+        },
+        { once: true }
+      )
+
+      this.#drain()
+    })
+  }
+
+  query(): Promise<LockManagerSnapshot> {
+    const held: LockInfo[] = Array.from(this.#held, (name) => ({
+      clientId: "test",
+      mode: "exclusive" as LockMode,
+      name,
+    }))
+    const pending: LockInfo[] = this.#pending.map((request) => ({
+      clientId: "test",
+      mode: request.options.mode ?? "exclusive",
+      name: request.name,
+    }))
+
+    return Promise.resolve({ held, pending })
+  }
+
+  #drain(): void {
+    for (const request of this.#pending) {
+      if (this.#held.has(request.name)) continue
+
+      this.#pending = this.#pending.filter((item) => item !== request)
+      this.#held.add(request.name)
+      void Promise.resolve(
+        request.callback({ mode: "exclusive", name: request.name })
+      )
+        .then(request.resolve, request.reject)
+        .finally(() => {
+          this.#held.delete(request.name)
+          this.#drain()
+        })
+      return
+    }
+  }
+}
+
+const navigatorWithLocks = globalThis.navigator as Navigator & {
+  locks?: LockManager
+}
+
+if (navigatorWithLocks.locks === undefined) {
+  Object.defineProperty(globalThis.navigator, "locks", {
+    configurable: true,
+    value: new TestLockManager(),
+  })
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -127,6 +127,7 @@ export default (({ command }: ConfigEnv) => {
       ],
     },
     test: {
+      setupFiles: ["./src/test/setup.ts"],
       coverage: {
         provider: "v8",
         reporter: ["text", "html", "lcov"],


### PR DESCRIPTION
## Summary
- Add a Vitest setup file that loads core-js polyfills for Promise.try and explicit resource management globals used by @evolu/common.
- Provide a minimal test LockManager implementation when navigator.locks is unavailable so Evolu-backed tests can run in the Vitest runtime.
- Register the setup file in Vitest config and declare the core-js promise-try proposal module for TypeScript.

## Verification
- bun run check
- bun run build

Follow-up for kanban task t_5c10bc3e.