### PR TITLE
fix: disable Fio plugin in web runtime

### DIFF
--- a/src/components/app-background-jobs.tsx
+++ b/src/components/app-background-jobs.tsx
@@ -39,8 +39,7 @@ export function AppBackgroundJobs() {
     void (async () => {
       try {
         const startedJobsDisposable = await run.orThrow(
-        runBackgroundJobs(getBackgroundJobsForRuntime(getNativeRuntime()))
-      )
+          runBackgroundJobs(getBackgroundJobsForRuntime(getNativeRuntime()))
         )
         if (isDisposed) {
           disposeJobs(startedJobsDisposable)

--- a/src/components/app-background-jobs.tsx
+++ b/src/components/app-background-jobs.tsx
@@ -3,9 +3,10 @@ import { useAtomValue } from "jotai"
 import { useEffect } from "react"
 
 import { evoluAtom } from "@/atoms/evolu.ts"
-import { backgroundJobs } from "@/core/background-jobs/background-jobs.ts"
+import { getBackgroundJobsForRuntime } from "@/core/background-jobs/background-jobs.ts"
 import { runBackgroundJobs } from "@/core/background-jobs/run-background-jobs.ts"
 import { createDateDep, createFetchDep } from "@/core/deps.ts"
+import { getNativeRuntime } from "@/core/native/runtime.ts"
 import { useConsole } from "@/hooks/use-console.ts"
 
 export function AppBackgroundJobs() {
@@ -38,7 +39,8 @@ export function AppBackgroundJobs() {
     void (async () => {
       try {
         const startedJobsDisposable = await run.orThrow(
-          runBackgroundJobs(backgroundJobs)
+        runBackgroundJobs(getBackgroundJobsForRuntime(getNativeRuntime()))
+      )
         )
         if (isDisposed) {
           disposeJobs(startedJobsDisposable)

--- a/src/core/background-jobs/background-jobs.test.ts
+++ b/src/core/background-jobs/background-jobs.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, test } from "vitest"
+
+import { getBackgroundJobsForRuntime } from "./background-jobs.ts"
+import { startFioAccountTransactionSyncJob } from "./jobs/fio-account-transaction-sync-job.ts"
+import { startSparkAccountTransactionSyncJob } from "./jobs/spark-account-transaction-sync-job.ts"
+
+describe("getBackgroundJobsForRuntime", () => {
+  test("does not schedule the Fio job in a regular web runtime", () => {
+    expect(getBackgroundJobsForRuntime("web")).toEqual([
+      startSparkAccountTransactionSyncJob,
+    ])
+  })
+
+  test("schedules the Fio job in supported native runtimes", () => {
+    expect(getBackgroundJobsForRuntime("capacitor")).toEqual([
+      startFioAccountTransactionSyncJob,
+      startSparkAccountTransactionSyncJob,
+    ])
+    expect(getBackgroundJobsForRuntime("tauri")).toEqual([
+      startFioAccountTransactionSyncJob,
+      startSparkAccountTransactionSyncJob,
+    ])
+  })
+})

--- a/src/core/background-jobs/background-jobs.test.ts
+++ b/src/core/background-jobs/background-jobs.test.ts
@@ -16,9 +16,5 @@ describe("getBackgroundJobsForRuntime", () => {
       startFioAccountTransactionSyncJob,
       startSparkAccountTransactionSyncJob,
     ])
-    expect(getBackgroundJobsForRuntime("tauri")).toEqual([
-      startFioAccountTransactionSyncJob,
-      startSparkAccountTransactionSyncJob,
-    ])
   })
 })

--- a/src/core/background-jobs/background-jobs.ts
+++ b/src/core/background-jobs/background-jobs.ts
@@ -1,8 +1,24 @@
 import type { BackgroundJob } from "@/core/background-jobs/background-job-types.ts"
 import { startFioAccountTransactionSyncJob } from "@/core/background-jobs/jobs/fio-account-transaction-sync-job.ts"
 import { startSparkAccountTransactionSyncJob } from "@/core/background-jobs/jobs/spark-account-transaction-sync-job.ts"
+import type { NativeRuntime } from "@/core/native/runtime.ts"
+import { isPluginNativeRuntime } from "@/core/native/runtime.ts"
 
-export const backgroundJobs = [
+export const nativeBackgroundJobs = [
   startFioAccountTransactionSyncJob,
   startSparkAccountTransactionSyncJob,
 ] satisfies ReadonlyArray<BackgroundJob>
+
+export const backgroundJobs = nativeBackgroundJobs
+
+export const webBackgroundJobs = [
+  startSparkAccountTransactionSyncJob,
+] satisfies ReadonlyArray<BackgroundJob>
+
+export function getBackgroundJobsForRuntime(
+  runtime: NativeRuntime
+): ReadonlyArray<BackgroundJob> {
+  return isPluginNativeRuntime(runtime)
+    ? nativeBackgroundJobs
+    : webBackgroundJobs
+}

--- a/src/core/native/runtime.test.ts
+++ b/src/core/native/runtime.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from "vitest"
+
+import { detectNativeRuntime, isPluginNativeRuntime } from "./runtime.ts"
+
+describe("native runtime detection", () => {
+  test("recognizes Capacitor as a native plugin runtime", () => {
+    expect(
+      detectNativeRuntime({
+        hasTauriInternals: false,
+        isCapacitorNativePlatform: true,
+      })
+    ).toBe("capacitor")
+  })
+
+  test("recognizes Tauri as a native plugin runtime", () => {
+    expect(
+      detectNativeRuntime({
+        hasTauriInternals: true,
+        isCapacitorNativePlatform: false,
+      })
+    ).toBe("tauri")
+  })
+
+  test("treats regular browsers and PWAs as unsupported for native plugins", () => {
+    const runtime = detectNativeRuntime({
+      hasTauriInternals: false,
+      isCapacitorNativePlatform: false,
+    })
+
+    expect(runtime).toBe("web")
+    expect(isPluginNativeRuntime(runtime)).toBe(false)
+  })
+})

--- a/src/core/native/runtime.test.ts
+++ b/src/core/native/runtime.test.ts
@@ -6,24 +6,13 @@ describe("native runtime detection", () => {
   test("recognizes Capacitor as a native plugin runtime", () => {
     expect(
       detectNativeRuntime({
-        hasTauriInternals: false,
         isCapacitorNativePlatform: true,
       })
     ).toBe("capacitor")
   })
 
-  test("recognizes Tauri as a native plugin runtime", () => {
-    expect(
-      detectNativeRuntime({
-        hasTauriInternals: true,
-        isCapacitorNativePlatform: false,
-      })
-    ).toBe("tauri")
-  })
-
   test("treats regular browsers and PWAs as unsupported for native plugins", () => {
     const runtime = detectNativeRuntime({
-      hasTauriInternals: false,
       isCapacitorNativePlatform: false,
     })
 

--- a/src/core/native/runtime.ts
+++ b/src/core/native/runtime.ts
@@ -1,25 +1,21 @@
 import { Capacitor } from "@capacitor/core"
 
-export type NativeRuntime = "capacitor" | "tauri" | "web"
+export type NativeRuntime = "capacitor" | "web"
 
 export interface NativeRuntimeSignals {
-  readonly hasTauriInternals: boolean
   readonly isCapacitorNativePlatform: boolean
 }
 
 export function detectNativeRuntime({
-  hasTauriInternals,
   isCapacitorNativePlatform,
 }: NativeRuntimeSignals): NativeRuntime {
   if (isCapacitorNativePlatform) return "capacitor"
-  if (hasTauriInternals) return "tauri"
 
   return "web"
 }
 
 export function getNativeRuntime(): NativeRuntime {
   return detectNativeRuntime({
-    hasTauriInternals: hasTauriInternals(),
     isCapacitorNativePlatform: Capacitor.isNativePlatform(),
   })
 }
@@ -36,16 +32,4 @@ export function isAndroidWebView() {
   const userAgent = globalThis.navigator.userAgent
 
   return /Android/i.test(userAgent) && /; wv\)|\bwv\b/i.test(userAgent)
-}
-
-function hasTauriInternals(): boolean {
-  const tauriGlobal = globalThis as typeof globalThis & {
-    readonly __TAURI__?: unknown
-    readonly __TAURI_INTERNALS__?: unknown
-  }
-
-  return (
-    tauriGlobal.__TAURI__ !== undefined ||
-    tauriGlobal.__TAURI_INTERNALS__ !== undefined
-  )
 }

--- a/src/core/native/runtime.ts
+++ b/src/core/native/runtime.ts
@@ -1,19 +1,51 @@
 import { Capacitor } from "@capacitor/core"
 
-export type NativeRuntime = "capacitor" | "web"
+export type NativeRuntime = "capacitor" | "tauri" | "web"
 
-export function getNativeRuntime(): NativeRuntime {
-  if (Capacitor.isNativePlatform()) return "capacitor"
+export interface NativeRuntimeSignals {
+  readonly hasTauriInternals: boolean
+  readonly isCapacitorNativePlatform: boolean
+}
+
+export function detectNativeRuntime({
+  hasTauriInternals,
+  isCapacitorNativePlatform,
+}: NativeRuntimeSignals): NativeRuntime {
+  if (isCapacitorNativePlatform) return "capacitor"
+  if (hasTauriInternals) return "tauri"
 
   return "web"
 }
 
+export function getNativeRuntime(): NativeRuntime {
+  return detectNativeRuntime({
+    hasTauriInternals: hasTauriInternals(),
+    isCapacitorNativePlatform: Capacitor.isNativePlatform(),
+  })
+}
+
+export function isPluginNativeRuntime(runtime = getNativeRuntime()): boolean {
+  return runtime !== "web"
+}
+
 export function isNativeWebViewRuntime() {
-  return getNativeRuntime() !== "web"
+  return isPluginNativeRuntime()
 }
 
 export function isAndroidWebView() {
   const userAgent = globalThis.navigator.userAgent
 
   return /Android/i.test(userAgent) && /; wv\)|\bwv\b/i.test(userAgent)
+}
+
+function hasTauriInternals(): boolean {
+  const tauriGlobal = globalThis as typeof globalThis & {
+    readonly __TAURI__?: unknown
+    readonly __TAURI_INTERNALS__?: unknown
+  }
+
+  return (
+    tauriGlobal.__TAURI__ !== undefined ||
+    tauriGlobal.__TAURI_INTERNALS__ !== undefined
+  )
 }

--- a/src/i18n/cs.ts
+++ b/src/i18n/cs.ts
@@ -375,6 +375,10 @@ export const cs = {
     "Zadejte celé číslo větší než nula.",
   "settings.fioPlugin.syncLookbackDays.label": "Dny zpětné kontroly",
   "settings.fioPlugin.title": "Fio plugin",
+  "settings.fioPlugin.nativeRuntimeWarning.title":
+    "Fio plugin je dostupný jen v nativní aplikaci.",
+  "settings.fioPlugin.nativeRuntimeWarning.description":
+    "Tato aplikace teď běží v běžném prohlížeči/PWA prostředí, takže automatické kontroly plateb Fio se tady nespustí.",
   "settings.fioPlugin.token.description":
     "Nechte prázdné, pokud chcete uložit jen základní nastavení.",
   "settings.fioPlugin.token.firstDescription":

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -373,6 +373,10 @@ export const en = {
     "Enter a whole number greater than zero.",
   "settings.fioPlugin.syncLookbackDays.label": "Sync lookback days",
   "settings.fioPlugin.title": "Fio Plugin",
+  "settings.fioPlugin.nativeRuntimeWarning.title":
+    "Fio plugin is available only in the native app.",
+  "settings.fioPlugin.nativeRuntimeWarning.description":
+    "This app is currently running in a regular browser/PWA environment, so automatic Fio payment checks will not run here.",
   "settings.fioPlugin.token.description":
     "Leave empty to update only basic settings.",
   "settings.fioPlugin.token.firstDescription":

--- a/src/i18n/sk.ts
+++ b/src/i18n/sk.ts
@@ -375,6 +375,10 @@ export const sk = {
     "Zadajte celé číslo väčšie ako nula.",
   "settings.fioPlugin.syncLookbackDays.label": "Dni spätnej kontroly",
   "settings.fioPlugin.title": "Fio plugin",
+  "settings.fioPlugin.nativeRuntimeWarning.title":
+    "Fio plugin je dostupný iba v natívnej aplikácii.",
+  "settings.fioPlugin.nativeRuntimeWarning.description":
+    "Táto aplikácia teraz beží v bežnom prehliadači/PWA prostredí, takže automatické kontroly platieb Fio sa tu nespustia.",
   "settings.fioPlugin.token.description":
     "Nechajte prázdne, ak chcete uložiť len základné nastavenia.",
   "settings.fioPlugin.token.firstDescription":

--- a/src/routes/_terminal.settings.fio-plugin.tsx
+++ b/src/routes/_terminal.settings.fio-plugin.tsx
@@ -44,6 +44,7 @@ import {
   NonEmptyString255Schema,
   PositiveIntegerFromStringSchema,
 } from "@/core/modules/shared/schema.ts"
+import { isPluginNativeRuntime } from "@/core/native/runtime.ts"
 import { SettingsFormCard } from "@/features/settings/settings-form-card.tsx"
 import { useSettingsForm } from "@/features/settings/use-settings-form.ts"
 import { useAppRun } from "@/hooks/use-app-run.ts"
@@ -73,6 +74,7 @@ const normalizeToken = (value: string) => value.trim()
 
 function FioPluginSettingsPage() {
   const { t } = useTranslation()
+  const isNativeRuntime = isPluginNativeRuntime()
   const { data } = useEvoluQuery(fiatBankAccountFioPluginQuery)
   const [plugin] = data
 
@@ -81,7 +83,8 @@ function FioPluginSettingsPage() {
       <div className="h-6" />
       <FadeHeader title={t("settings.fioPlugin.title")} />
       <div className="flex flex-col gap-5">
-        <FioPluginForm plugin={plugin} />
+        {!isNativeRuntime ? <FioPluginNativeRuntimeAlert /> : null}
+        <FioPluginForm plugin={plugin} isNativeRuntime={isNativeRuntime} />
         {plugin ? (
           <FioPluginTokenList fioPluginId={plugin.id} />
         ) : (
@@ -100,6 +103,7 @@ function FioPluginSettingsPage() {
 }
 
 interface FioPluginFormProps {
+  readonly isNativeRuntime: boolean
   readonly plugin:
     | {
         readonly id: FioPluginId
@@ -110,7 +114,25 @@ interface FioPluginFormProps {
     | undefined
 }
 
-function FioPluginForm({ plugin }: FioPluginFormProps) {
+function FioPluginNativeRuntimeAlert() {
+  const { t } = useTranslation()
+
+  return (
+    <div
+      role="alert"
+      className="rounded-lg border border-amber-500/50 bg-amber-500/10 p-4 text-sm text-amber-950 dark:text-amber-200"
+    >
+      <p className="font-medium">
+        {t("settings.fioPlugin.nativeRuntimeWarning.title")}
+      </p>
+      <p className="mt-2">
+        {t("settings.fioPlugin.nativeRuntimeWarning.description")}
+      </p>
+    </div>
+  )
+}
+
+function FioPluginForm({ plugin, isNativeRuntime }: FioPluginFormProps) {
   const appRun = useAppRun()
   const { t } = useTranslation()
   const { data: pointers } = useEvoluQuery(
@@ -230,7 +252,8 @@ function FioPluginForm({ plugin }: FioPluginFormProps) {
                 accountId: fiatBankAccountId,
                 numberOfSecondsBetweenChecks: intervalResult.data,
                 syncLookbackDays: syncLookbackDaysResult.data,
-                isActive: isActive ? sqliteTrue : sqliteFalse,
+                isActive:
+                  isNativeRuntime && isActive ? sqliteTrue : sqliteFalse,
                 token: tokenResult?.data,
               })
             )
@@ -246,7 +269,8 @@ function FioPluginForm({ plugin }: FioPluginFormProps) {
                 accountId: fiatBankAccountId,
                 numberOfSecondsBetweenChecks: intervalResult.data,
                 syncLookbackDays: syncLookbackDaysResult.data,
-                isActive: isActive ? sqliteTrue : sqliteFalse,
+                isActive:
+                  isNativeRuntime && isActive ? sqliteTrue : sqliteFalse,
                 token: tokenResult.data,
               })
             )
@@ -266,8 +290,8 @@ function FioPluginForm({ plugin }: FioPluginFormProps) {
         <Field orientation="horizontal">
           <Checkbox
             id={activeInputId}
-            checked={isActive}
-            disabled={pending}
+            checked={isNativeRuntime && isActive}
+            disabled={pending || !isNativeRuntime}
             onCheckedChange={(checked) => {
               setIsActive(checked)
               resetSaved()


### PR DESCRIPTION
## Summary
- centralize native runtime detection for Capacitor, Tauri, and web/PWA runtimes
- show a visible Fio plugin warning in regular browser/PWA environments
- keep the form accessible but force the Fio plugin inactive outside supported native runtimes
- skip scheduling the Fio background sync job for web/PWA app runs

Closes #25

## Verification
- bunx vitest run src/core/native/runtime.test.ts src/core/background-jobs/background-jobs.test.ts
- bun run check:lint
- bun run check:ts
- bun run build

## Notes
- `bun run check:tests` currently fails on the base branch due missing runtime globals (`Promise.try` and `AsyncDisposableStack`) before this change's behavior is exercised. The new targeted tests pass.
