### PR TITLE
fix(withdraw): preserve Base58 address casing

### DIFF
--- a/src/features/withdraw/withdraw-page.tsx
+++ b/src/features/withdraw/withdraw-page.tsx
@@ -54,6 +54,7 @@ import { useTranslation } from "@/hooks/use-translation.ts"
 import type { TranslationKey } from "@/i18n/resources.ts"
 import { WithdrawQrScanner } from "./withdraw-qr-scanner.tsx"
 import {
+  formatAddressGroups,
   formatSatsAmount,
   type ScannedBitcoinAddress,
 } from "./withdraw-utils.ts"
@@ -101,12 +102,6 @@ const confirmErrorKey = (error: ConfirmWithdrawalError): TranslationKey => {
       return "withdraw.review.error.sparkFailed"
   }
 }
-
-const formatAddressGroups = (address: string): string =>
-  address
-    .toLocaleLowerCase()
-    .replaceAll(/\s+/gu, "")
-    .replaceAll(/(.{4})(?=.)/gu, "$1 ")
 
 export function WithdrawPage() {
   const appRun = useAppRun()

--- a/src/features/withdraw/withdraw-utils.test.ts
+++ b/src/features/withdraw/withdraw-utils.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, test } from "vitest"
-import { parseScannedBitcoinAddress } from "./withdraw-utils.ts"
+import {
+  formatAddressGroups,
+  parseScannedBitcoinAddress,
+} from "./withdraw-utils.ts"
 
 describe("parseScannedBitcoinAddress", () => {
   test("returns a bare address unchanged", () => {
@@ -34,5 +37,17 @@ describe("parseScannedBitcoinAddress", () => {
     expect(
       parseScannedBitcoinAddress("  1BvBMSEYstWetqTFn5Au4m4GFg7xJaNVN2  ")
     ).toEqual({ address: "1BvBMSEYstWetqTFn5Au4m4GFg7xJaNVN2" })
+  })
+})
+
+describe("formatAddressGroups", () => {
+  test("groups a Base58 address without changing its casing", () => {
+    expect(formatAddressGroups("1BvBMSEYstWetqTFn5Au4m4GFg7xJaNVN2")).toBe(
+      "1BvB MSEY stWe tqTF n5Au 4m4G Fg7x JaNV N2"
+    )
+  })
+
+  test("removes existing spacing before applying four-character groups", () => {
+    expect(formatAddressGroups("bc1q ar0s rrr7 xfk")).toBe("bc1q ar0s rrr7 xfk")
   })
 })

--- a/src/features/withdraw/withdraw-utils.ts
+++ b/src/features/withdraw/withdraw-utils.ts
@@ -32,5 +32,8 @@ export const parseScannedBitcoinAddress = (
   }
 }
 
+export const formatAddressGroups = (address: string): string =>
+  address.replaceAll(/\s+/gu, "").replaceAll(/(.{4})(?=.)/gu, "$1 ")
+
 export const formatSatsAmount = (sats: number, locale: string): string =>
   new Intl.NumberFormat(locale).format(sats)


### PR DESCRIPTION
## Summary
- moves withdraw address grouping into a tested helper
- removes lowercasing from withdraw review address formatting so Base58 casing is preserved
- keeps whitespace stripping and 4-character grouping behavior unchanged

## Verification
- bunx vitest run src/features/withdraw/withdraw-utils.test.ts - passed (6 tests)
- bun run check:lint - passed
- bun run check:ts - passed
- bun run build - passed
- bun run check:tests - failed on existing runtime globals issue: Promise.try is not a function / AsyncDisposableStack is not defined; touched withdraw-utils test still passed in the full run

Kanban task: t_662597ca