### PR TITLE
fix: distinguish withdrawal failure types

### DIFF
--- a/src/core/modules/withdrawal/withdrawal-actions.test.ts
+++ b/src/core/modules/withdrawal/withdrawal-actions.test.ts
@@ -332,7 +332,7 @@ describe("executeWithdrawal", () => {
       ])
   })
 
-  test("fails when the wallet cannot complete the withdrawal", async () => {
+  test("fails when the wallet cannot complete the withdrawal request", async () => {
     await using testEvolu = await createEvoluTest()
     const { evolu } = testEvolu
     const accountId = await createSparkAccount({ evolu })
@@ -362,7 +362,45 @@ describe("executeWithdrawal", () => {
 
     expect(result).toMatchObject({
       ok: false,
-      error: { type: "WithdrawalFailed" },
+      error: { type: "WithdrawalRequestFailed" },
+    })
+  })
+
+  test("fails separately when the withdrawal transaction cannot be recorded", async () => {
+    await using testEvolu = await createEvoluTest()
+    const { evolu } = testEvolu
+    const accountId = await createSparkAccount({ evolu })
+    const deps = {
+      evolu,
+      ...createDateDeps(),
+      sparkWallet: {
+        create: async () => ({
+          withdraw: async () => ({
+            id: "",
+            status: "INITIATED",
+            txid: "txid-3",
+          }),
+        }),
+      },
+    } satisfies EvoluDep & DateDep & SparkWalletDep
+    await using run = testCreateRun(deps)
+    const exitSpeed: SparkExitSpeed = "medium"
+
+    const result = await run(
+      executeWithdrawal({
+        accountId,
+        onchainAddress: validAddress,
+        amountSats: 10_000,
+        withdrawAll: false,
+        availableSats: 100_000,
+        exitSpeed,
+        feeQuote,
+      })
+    )
+
+    expect(result).toMatchObject({
+      ok: false,
+      error: { type: "WithdrawalRecordingFailed" },
     })
   })
 })

--- a/src/core/modules/withdrawal/withdrawal-actions.ts
+++ b/src/core/modules/withdrawal/withdrawal-actions.ts
@@ -23,12 +23,13 @@ import {
   createInsufficientWithdrawalBalanceError,
   createInvalidBitcoinAddressError,
   createWithdrawalAccountNotFoundError,
-  createWithdrawalFailedError,
   createWithdrawalQuoteFailedError,
+  createWithdrawalRecordingFailedError,
+  createWithdrawalRequestFailedError,
+  type ExecuteWithdrawalError,
   type InsufficientWithdrawalBalanceError,
   type InvalidBitcoinAddressError,
   type WithdrawalAccountNotFoundError,
-  type WithdrawalFailedError,
   type WithdrawalQuoteFailedError,
 } from "./withdrawal-types.ts"
 import {
@@ -151,7 +152,7 @@ export const executeWithdrawal =
       readonly txid: string | null
       readonly status: string
     },
-    WithdrawalAccountNotFoundError | WithdrawalFailedError,
+    ExecuteWithdrawalError,
     EvoluDep & EvoluOwnerIdDep & DateDep & SparkWalletDep
   > =>
   async (run) => {
@@ -175,59 +176,70 @@ export const executeWithdrawal =
       })
       if (!result) {
         return err(
-          createWithdrawalFailedError({
+          createWithdrawalRequestFailedError({
             message: "The withdrawal request could not be completed",
           })
         )
       }
 
-      const totalDebitedSats = computeTotalDebitedSats({
-        amountSats,
-        withdrawAll,
-        availableSats,
-        feeSats: feeEstimate.totalFeeSats,
-      })
-
-      const accountTransactionResult = await run(
-        createAccountTransaction({
-          accountId,
-          amount: Integer(-totalDebitedSats),
-          currency: "BTC",
-          occurredAt: TimestampMsSchema.decode(run.deps.date.now().getTime()),
-          note: null,
-          internalTransferGroupId: null,
-          onchain: {
-            onchainAddress: NonEmptyStringSchema.decode(onchainAddress),
-            coopExitRequestId: NonEmptyStringSchema.decode(result.id),
-            exitSpeed,
-            feeSats: Integer(feeEstimate.totalFeeSats),
-            txid:
-              result.txid === null
-                ? null
-                : NonEmptyStringSchema.decode(result.txid),
-          },
-          source: {
-            deviceId: deviceId ?? null,
-            source: "manual",
-          },
+      try {
+        const totalDebitedSats = computeTotalDebitedSats({
+          amountSats,
+          withdrawAll,
+          availableSats,
+          feeSats: feeEstimate.totalFeeSats,
         })
-      )
-      if (!accountTransactionResult.ok) {
+
+        const accountTransactionResult = await run(
+          createAccountTransaction({
+            accountId,
+            amount: Integer(-totalDebitedSats),
+            currency: "BTC",
+            occurredAt: TimestampMsSchema.decode(run.deps.date.now().getTime()),
+            note: null,
+            internalTransferGroupId: null,
+            onchain: {
+              onchainAddress: NonEmptyStringSchema.decode(onchainAddress),
+              coopExitRequestId: NonEmptyStringSchema.decode(result.id),
+              exitSpeed,
+              feeSats: Integer(feeEstimate.totalFeeSats),
+              txid:
+                result.txid === null
+                  ? null
+                  : NonEmptyStringSchema.decode(result.txid),
+            },
+            source: {
+              deviceId: deviceId ?? null,
+              source: "manual",
+            },
+          })
+        )
+        if (!accountTransactionResult.ok) {
+          return err(
+            createWithdrawalRecordingFailedError({
+              message: "Failed to record the withdrawal transaction",
+            })
+          )
+        }
+
+        return ok({
+          accountTransactionId: accountTransactionResult.value,
+          txid: result.txid,
+          status: result.status,
+        })
+      } catch (error) {
         return err(
-          createWithdrawalFailedError({
-            message: "Failed to record the withdrawal transaction",
+          createWithdrawalRecordingFailedError({
+            message:
+              error instanceof Error
+                ? error.message
+                : "Failed to record the withdrawal transaction",
           })
         )
       }
-
-      return ok({
-        accountTransactionId: accountTransactionResult.value,
-        txid: result.txid,
-        status: result.status,
-      })
     } catch (error) {
       return err(
-        createWithdrawalFailedError({
+        createWithdrawalRequestFailedError({
           message:
             error instanceof Error
               ? error.message

--- a/src/core/modules/withdrawal/withdrawal-types.ts
+++ b/src/core/modules/withdrawal/withdrawal-types.ts
@@ -44,3 +44,29 @@ export const createWithdrawalFailedError = defineError("WithdrawalFailed")<{
 export type WithdrawalFailedError = ReturnType<
   typeof createWithdrawalFailedError
 >
+
+export const createWithdrawalRequestFailedError = defineError(
+  "WithdrawalRequestFailed"
+)<{
+  readonly message: string
+}>()
+export type WithdrawalRequestFailedError = ReturnType<
+  typeof createWithdrawalRequestFailedError
+>
+
+export const createWithdrawalRecordingFailedError = defineError(
+  "WithdrawalRecordingFailed"
+)<{
+  readonly message: string
+}>()
+export type WithdrawalRecordingFailedError = ReturnType<
+  typeof createWithdrawalRecordingFailedError
+>
+
+export type ExecuteWithdrawalFailureError =
+  | WithdrawalRequestFailedError
+  | WithdrawalRecordingFailedError
+
+export type ExecuteWithdrawalError =
+  | WithdrawalAccountNotFoundError
+  | ExecuteWithdrawalFailureError

--- a/src/features/withdraw/withdraw-page.tsx
+++ b/src/features/withdraw/withdraw-page.tsx
@@ -94,10 +94,10 @@ const confirmErrorKey = (error: ConfirmWithdrawalError): TranslationKey => {
       return "withdraw.review.error.interrupted"
     case "WithdrawalAccountNotFound":
       return "withdraw.error.accountNotFound"
-    case "WithdrawalFailed":
-      return error.message === "Failed to record the withdrawal transaction"
-        ? "withdraw.review.error.recordFailed"
-        : "withdraw.review.error.sparkFailed"
+    case "WithdrawalRequestFailed":
+      return "withdraw.review.error.sparkFailed"
+    case "WithdrawalRecordingFailed":
+      return "withdraw.review.error.recordFailed"
     default:
       return "withdraw.review.error.sparkFailed"
   }


### PR DESCRIPTION
## Summary
- add discriminated executeWithdrawal failure types for request and recording failures
- use the new error types from withdrawal action results and withdraw UI error mapping
- add regression coverage for both executeWithdrawal failure modes

## Verification
- bun run check:lint - passed
- bun run check:ts - passed
- bun run build - passed
- bun run vitest run src/core/modules/withdrawal/withdrawal-actions.test.ts - failed before test assertions because this Node runtime lacks AsyncDisposableStack
- bun run check:tests - failed for the same environment issue across existing Evolu-backed tests (AsyncDisposableStack / Promise.try unavailable)
