### PR TITLE
fix: type withdrawal page error mapping

### DIFF
--- a/src/core/modules/withdrawal/withdrawal-actions.test.ts
+++ b/src/core/modules/withdrawal/withdrawal-actions.test.ts
@@ -332,7 +332,7 @@ describe("executeWithdrawal", () => {
       ])
   })
 
-  test("fails when the wallet cannot complete the withdrawal", async () => {
+  test("fails when the wallet cannot complete the withdrawal request", async () => {
     await using testEvolu = await createEvoluTest()
     const { evolu } = testEvolu
     const accountId = await createSparkAccount({ evolu })
@@ -362,7 +362,45 @@ describe("executeWithdrawal", () => {
 
     expect(result).toMatchObject({
       ok: false,
-      error: { type: "WithdrawalFailed" },
+      error: { type: "WithdrawalRequestFailed" },
+    })
+  })
+
+  test("fails separately when the withdrawal transaction cannot be recorded", async () => {
+    await using testEvolu = await createEvoluTest()
+    const { evolu } = testEvolu
+    const accountId = await createSparkAccount({ evolu })
+    const deps = {
+      evolu,
+      ...createDateDeps(),
+      sparkWallet: {
+        create: async () => ({
+          withdraw: async () => ({
+            id: "",
+            status: "INITIATED",
+            txid: "txid-3",
+          }),
+        }),
+      },
+    } satisfies EvoluDep & DateDep & SparkWalletDep
+    await using run = testCreateRun(deps)
+    const exitSpeed: SparkExitSpeed = "medium"
+
+    const result = await run(
+      executeWithdrawal({
+        accountId,
+        onchainAddress: validAddress,
+        amountSats: 10_000,
+        withdrawAll: false,
+        availableSats: 100_000,
+        exitSpeed,
+        feeQuote,
+      })
+    )
+
+    expect(result).toMatchObject({
+      ok: false,
+      error: { type: "WithdrawalRecordingFailed" },
     })
   })
 })

--- a/src/core/modules/withdrawal/withdrawal-actions.ts
+++ b/src/core/modules/withdrawal/withdrawal-actions.ts
@@ -23,12 +23,13 @@ import {
   createInsufficientWithdrawalBalanceError,
   createInvalidBitcoinAddressError,
   createWithdrawalAccountNotFoundError,
-  createWithdrawalFailedError,
   createWithdrawalQuoteFailedError,
+  createWithdrawalRecordingFailedError,
+  createWithdrawalRequestFailedError,
+  type ExecuteWithdrawalError,
   type InsufficientWithdrawalBalanceError,
   type InvalidBitcoinAddressError,
   type WithdrawalAccountNotFoundError,
-  type WithdrawalFailedError,
   type WithdrawalQuoteFailedError,
 } from "./withdrawal-types.ts"
 import {
@@ -151,7 +152,7 @@ export const executeWithdrawal =
       readonly txid: string | null
       readonly status: string
     },
-    WithdrawalAccountNotFoundError | WithdrawalFailedError,
+    ExecuteWithdrawalError,
     EvoluDep & EvoluOwnerIdDep & DateDep & SparkWalletDep
   > =>
   async (run) => {
@@ -175,59 +176,70 @@ export const executeWithdrawal =
       })
       if (!result) {
         return err(
-          createWithdrawalFailedError({
+          createWithdrawalRequestFailedError({
             message: "The withdrawal request could not be completed",
           })
         )
       }
 
-      const totalDebitedSats = computeTotalDebitedSats({
-        amountSats,
-        withdrawAll,
-        availableSats,
-        feeSats: feeEstimate.totalFeeSats,
-      })
-
-      const accountTransactionResult = await run(
-        createAccountTransaction({
-          accountId,
-          amount: Integer(-totalDebitedSats),
-          currency: "BTC",
-          occurredAt: TimestampMsSchema.decode(run.deps.date.now().getTime()),
-          note: null,
-          internalTransferGroupId: null,
-          onchain: {
-            onchainAddress: NonEmptyStringSchema.decode(onchainAddress),
-            coopExitRequestId: NonEmptyStringSchema.decode(result.id),
-            exitSpeed,
-            feeSats: Integer(feeEstimate.totalFeeSats),
-            txid:
-              result.txid === null
-                ? null
-                : NonEmptyStringSchema.decode(result.txid),
-          },
-          source: {
-            deviceId: deviceId ?? null,
-            source: "manual",
-          },
+      try {
+        const totalDebitedSats = computeTotalDebitedSats({
+          amountSats,
+          withdrawAll,
+          availableSats,
+          feeSats: feeEstimate.totalFeeSats,
         })
-      )
-      if (!accountTransactionResult.ok) {
+
+        const accountTransactionResult = await run(
+          createAccountTransaction({
+            accountId,
+            amount: Integer(-totalDebitedSats),
+            currency: "BTC",
+            occurredAt: TimestampMsSchema.decode(run.deps.date.now().getTime()),
+            note: null,
+            internalTransferGroupId: null,
+            onchain: {
+              onchainAddress: NonEmptyStringSchema.decode(onchainAddress),
+              coopExitRequestId: NonEmptyStringSchema.decode(result.id),
+              exitSpeed,
+              feeSats: Integer(feeEstimate.totalFeeSats),
+              txid:
+                result.txid === null
+                  ? null
+                  : NonEmptyStringSchema.decode(result.txid),
+            },
+            source: {
+              deviceId: deviceId ?? null,
+              source: "manual",
+            },
+          })
+        )
+        if (!accountTransactionResult.ok) {
+          return err(
+            createWithdrawalRecordingFailedError({
+              message: "Failed to record the withdrawal transaction",
+            })
+          )
+        }
+
+        return ok({
+          accountTransactionId: accountTransactionResult.value,
+          txid: result.txid,
+          status: result.status,
+        })
+      } catch (error) {
         return err(
-          createWithdrawalFailedError({
-            message: "Failed to record the withdrawal transaction",
+          createWithdrawalRecordingFailedError({
+            message:
+              error instanceof Error
+                ? error.message
+                : "Failed to record the withdrawal transaction",
           })
         )
       }
-
-      return ok({
-        accountTransactionId: accountTransactionResult.value,
-        txid: result.txid,
-        status: result.status,
-      })
     } catch (error) {
       return err(
-        createWithdrawalFailedError({
+        createWithdrawalRequestFailedError({
           message:
             error instanceof Error
               ? error.message

--- a/src/core/modules/withdrawal/withdrawal-actions.ts
+++ b/src/core/modules/withdrawal/withdrawal-actions.ts
@@ -27,10 +27,7 @@ import {
   createWithdrawalRecordingFailedError,
   createWithdrawalRequestFailedError,
   type ExecuteWithdrawalError,
-  type InsufficientWithdrawalBalanceError,
-  type InvalidBitcoinAddressError,
-  type WithdrawalAccountNotFoundError,
-  type WithdrawalQuoteFailedError,
+  type QuoteWithdrawalError,
 } from "./withdrawal-types.ts"
 import {
   computeTotalDebitedSats,
@@ -61,14 +58,7 @@ export const quoteWithdrawal =
     readonly accountId: AccountId
     readonly onchainAddress: string
     readonly amountSats?: PositiveInteger
-  }): Task<
-    WithdrawalQuote,
-    | WithdrawalAccountNotFoundError
-    | InvalidBitcoinAddressError
-    | InsufficientWithdrawalBalanceError
-    | WithdrawalQuoteFailedError,
-    EvoluDep & SparkWalletDep
-  > =>
+  }): Task<WithdrawalQuote, QuoteWithdrawalError, EvoluDep & SparkWalletDep> =>
   async (run) => {
     if (!isValidBitcoinAddress(onchainAddress)) {
       return err(createInvalidBitcoinAddressError({ address: onchainAddress }))

--- a/src/core/modules/withdrawal/withdrawal-types.ts
+++ b/src/core/modules/withdrawal/withdrawal-types.ts
@@ -44,3 +44,29 @@ export const createWithdrawalFailedError = defineError("WithdrawalFailed")<{
 export type WithdrawalFailedError = ReturnType<
   typeof createWithdrawalFailedError
 >
+
+export const createWithdrawalRequestFailedError = defineError(
+  "WithdrawalRequestFailed"
+)<{
+  readonly message: string
+}>()
+export type WithdrawalRequestFailedError = ReturnType<
+  typeof createWithdrawalRequestFailedError
+>
+
+export const createWithdrawalRecordingFailedError = defineError(
+  "WithdrawalRecordingFailed"
+)<{
+  readonly message: string
+}>()
+export type WithdrawalRecordingFailedError = ReturnType<
+  typeof createWithdrawalRecordingFailedError
+>
+
+export type ExecuteWithdrawalFailureError =
+  | WithdrawalRequestFailedError
+  | WithdrawalRecordingFailedError
+
+export type ExecuteWithdrawalError =
+  | WithdrawalAccountNotFoundError
+  | ExecuteWithdrawalFailureError

--- a/src/core/modules/withdrawal/withdrawal-types.ts
+++ b/src/core/modules/withdrawal/withdrawal-types.ts
@@ -67,6 +67,12 @@ export type ExecuteWithdrawalFailureError =
   | WithdrawalRequestFailedError
   | WithdrawalRecordingFailedError
 
+export type QuoteWithdrawalError =
+  | WithdrawalAccountNotFoundError
+  | InvalidBitcoinAddressError
+  | InsufficientWithdrawalBalanceError
+  | WithdrawalQuoteFailedError
+
 export type ExecuteWithdrawalError =
   | WithdrawalAccountNotFoundError
   | ExecuteWithdrawalFailureError

--- a/src/features/withdraw/withdraw-page.tsx
+++ b/src/features/withdraw/withdraw-page.tsx
@@ -94,10 +94,10 @@ const confirmErrorKey = (error: ConfirmWithdrawalError): TranslationKey => {
       return "withdraw.review.error.interrupted"
     case "WithdrawalAccountNotFound":
       return "withdraw.error.accountNotFound"
-    case "WithdrawalFailed":
-      return error.message === "Failed to record the withdrawal transaction"
-        ? "withdraw.review.error.recordFailed"
-        : "withdraw.review.error.sparkFailed"
+    case "WithdrawalRequestFailed":
+      return "withdraw.review.error.sparkFailed"
+    case "WithdrawalRecordingFailed":
+      return "withdraw.review.error.recordFailed"
     default:
       return "withdraw.review.error.sparkFailed"
   }

--- a/src/features/withdraw/withdraw-page.tsx
+++ b/src/features/withdraw/withdraw-page.tsx
@@ -1,4 +1,6 @@
+import type { AbortError } from "@evolu/common"
 import { Link } from "@tanstack/react-router"
+import assertNever from "assert-never"
 import {
   ArrowLeftIcon,
   ClipboardPasteIcon,
@@ -42,6 +44,10 @@ import {
   quoteWithdrawal,
   type WithdrawalQuote,
 } from "@/core/modules/withdrawal/withdrawal-actions.ts"
+import type {
+  ExecuteWithdrawalError,
+  QuoteWithdrawalError,
+} from "@/core/modules/withdrawal/withdrawal-types.ts"
 import { isValidBitcoinAddress } from "@/core/modules/withdrawal/withdrawal-utils.ts"
 import {
   createDefaultSparkPaymentWallet,
@@ -70,23 +76,26 @@ const exitSpeedOptions: ReadonlyArray<{
   { value: "slow", label: "withdraw.review.speed.slow" },
 ]
 
-const quoteErrorKey = (errorType: string): TranslationKey => {
-  switch (errorType) {
+const quoteErrorKey = (
+  error: QuoteWithdrawalError | AbortError
+): TranslationKey => {
+  switch (error.type) {
+    case "AbortError":
+      return "withdraw.quoteError.generic"
     case "WithdrawalAccountNotFound":
       return "withdraw.error.accountNotFound"
     case "InvalidBitcoinAddress":
       return "withdraw.address.invalid"
     case "InsufficientWithdrawalBalance":
       return "withdraw.error.insufficientBalance"
-    default:
+    case "WithdrawalQuoteFailed":
       return "withdraw.quoteError.generic"
   }
+
+  return assertNever(error)
 }
 
-interface ConfirmWithdrawalError {
-  readonly type: string
-  readonly message?: string
-}
+type ConfirmWithdrawalError = ExecuteWithdrawalError | AbortError
 
 const confirmErrorKey = (error: ConfirmWithdrawalError): TranslationKey => {
   switch (error.type) {
@@ -98,9 +107,9 @@ const confirmErrorKey = (error: ConfirmWithdrawalError): TranslationKey => {
       return "withdraw.review.error.sparkFailed"
     case "WithdrawalRecordingFailed":
       return "withdraw.review.error.recordFailed"
-    default:
-      return "withdraw.review.error.sparkFailed"
   }
+
+  return assertNever(error)
 }
 
 export function WithdrawPage() {
@@ -229,7 +238,7 @@ export function WithdrawPage() {
       )
 
       if (!quoteResult.ok) {
-        setQuoteError(quoteErrorKey(quoteResult.error.type))
+        setQuoteError(quoteErrorKey(quoteResult.error))
         return
       }
 


### PR DESCRIPTION
## Summary
- Types the withdraw page error mappers against the exported withdrawal action error unions.
- Maps `WithdrawalRequestFailed` and `WithdrawalRecordingFailed` through explicit exhaustive branches instead of a generic/default failure path.
- Reuses the exported quote error union so quote error mapping is exhaustively checked too.

Builds on PR #39, which introduced the distinct executeWithdrawal failure types.

## Verification
- `bun run check:lint` passed
- `bun run check:ts` passed
- `bun run build` passed
- `bun run check:tests` failed due existing local runtime blockers: `Promise.try is not a function` and `AsyncDisposableStack is not defined` in Evolu-backed tests
