### PR TITLE
Add setup status overview screen

### DIFF
--- a/src/features/settings/readiness/readiness-utils.test.ts
+++ b/src/features/settings/readiness/readiness-utils.test.ts
@@ -11,6 +11,7 @@ const baseInput = {
   hasDefaultPaymentMethod: true,
   isDefaultPaymentMethodAvailable: true,
   hasActiveFioPlugin: true,
+  hasActiveFioPluginToken: true,
 }
 
 describe("createReadinessItems", () => {
@@ -36,6 +37,7 @@ describe("createReadinessItems", () => {
       hasDefaultPaymentMethod: false,
       isDefaultPaymentMethodAvailable: false,
       hasActiveFioPlugin: false,
+      hasActiveFioPluginToken: false,
     })
 
     expect(items).toEqual([
@@ -81,6 +83,26 @@ describe("createReadinessItems", () => {
     expect(items.find((item) => item.id === "fioPlugin")?.completed).toBe(false)
   })
 
+  it("marks Fio incomplete when bank payments are active with an active plugin but no token", () => {
+    const items = createReadinessItems({
+      ...baseInput,
+      hasActiveFioPluginToken: false,
+    })
+
+    expect(items.find((item) => item.id === "fioPlugin")?.completed).toBe(false)
+  })
+
+  it("marks Fio complete when bank payments are inactive even without a plugin token", () => {
+    const items = createReadinessItems({
+      ...baseInput,
+      hasActiveFiatBankAccount: false,
+      hasActiveFioPlugin: false,
+      hasActiveFioPluginToken: false,
+    })
+
+    expect(items.find((item) => item.id === "fioPlugin")?.completed).toBe(true)
+  })
+
   it("accepts any active payment method and only requires Fio for bank payments", () => {
     const items = createReadinessItems({
       ...baseInput,
@@ -88,6 +110,7 @@ describe("createReadinessItems", () => {
       hasActiveCashRegisterAccount: true,
       hasActiveFiatBankAccount: false,
       hasActiveFioPlugin: false,
+      hasActiveFioPluginToken: false,
     })
 
     expect(items.find((item) => item.id === "paymentMethods")?.completed).toBe(

--- a/src/features/settings/readiness/readiness-utils.test.ts
+++ b/src/features/settings/readiness/readiness-utils.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest"
+
+import { createReadinessItems } from "./readiness-utils.ts"
+
+const baseInput = {
+  hasRecoveryPhrase: true,
+  hasActiveSyncTransport: true,
+  hasActiveSparkAccount: true,
+  hasActiveCashRegisterAccount: false,
+  hasActiveFiatBankAccount: true,
+  hasDefaultPaymentMethod: true,
+  isDefaultPaymentMethodAvailable: true,
+  hasActiveFioPlugin: true,
+}
+
+describe("createReadinessItems", () => {
+  it("marks the setup checklist complete when required state is ready", () => {
+    const items = createReadinessItems(baseInput)
+
+    expect(items).toEqual([
+      expect.objectContaining({ id: "recoveryPhrase", completed: true }),
+      expect.objectContaining({ id: "sync", completed: true }),
+      expect.objectContaining({ id: "paymentMethods", completed: true }),
+      expect.objectContaining({ id: "defaultPaymentMethod", completed: true }),
+      expect.objectContaining({ id: "bankAccount", completed: true }),
+      expect.objectContaining({ id: "fioPlugin", completed: true }),
+    ])
+  })
+
+  it("marks missing setup as incomplete and points to the relevant settings screens", () => {
+    const items = createReadinessItems({
+      ...baseInput,
+      hasActiveSyncTransport: false,
+      hasActiveSparkAccount: false,
+      hasActiveFiatBankAccount: false,
+      hasDefaultPaymentMethod: false,
+      isDefaultPaymentMethodAvailable: false,
+      hasActiveFioPlugin: false,
+    })
+
+    expect(items).toEqual([
+      expect.objectContaining({
+        id: "recoveryPhrase",
+        completed: true,
+        actionTo: "/settings/security",
+      }),
+      expect.objectContaining({
+        id: "sync",
+        completed: false,
+        actionTo: "/settings/security",
+      }),
+      expect.objectContaining({
+        id: "paymentMethods",
+        completed: false,
+        actionTo: "/settings/payment-accounts",
+      }),
+      expect.objectContaining({
+        id: "defaultPaymentMethod",
+        completed: false,
+        actionTo: "/settings/default-payment-method",
+      }),
+      expect.objectContaining({
+        id: "bankAccount",
+        completed: false,
+        actionTo: "/settings/payment-accounts",
+      }),
+      expect.objectContaining({
+        id: "fioPlugin",
+        completed: true,
+        actionTo: "/settings/fio-plugin",
+      }),
+    ])
+  })
+
+  it("marks Fio incomplete when bank payments are active without an active plugin", () => {
+    const items = createReadinessItems({
+      ...baseInput,
+      hasActiveFioPlugin: false,
+    })
+
+    expect(items.find((item) => item.id === "fioPlugin")?.completed).toBe(false)
+  })
+
+  it("accepts any active payment method and only requires Fio for bank payments", () => {
+    const items = createReadinessItems({
+      ...baseInput,
+      hasActiveSparkAccount: false,
+      hasActiveCashRegisterAccount: true,
+      hasActiveFiatBankAccount: false,
+      hasActiveFioPlugin: false,
+    })
+
+    expect(items.find((item) => item.id === "paymentMethods")?.completed).toBe(
+      true
+    )
+    expect(items.find((item) => item.id === "bankAccount")?.completed).toBe(
+      false
+    )
+    expect(items.find((item) => item.id === "fioPlugin")?.completed).toBe(true)
+  })
+})

--- a/src/features/settings/readiness/readiness-utils.ts
+++ b/src/features/settings/readiness/readiness-utils.ts
@@ -1,0 +1,122 @@
+import type { LinkProps } from "@tanstack/react-router"
+
+import type { DefaultPaymentMethod } from "@/core/modules/app-settings/app-settings-types.ts"
+import type { TranslationKey } from "@/i18n/resources.ts"
+
+export type ReadinessItemId =
+  | "recoveryPhrase"
+  | "sync"
+  | "paymentMethods"
+  | "defaultPaymentMethod"
+  | "bankAccount"
+  | "fioPlugin"
+
+export interface ReadinessStateInput {
+  readonly hasRecoveryPhrase: boolean
+  readonly hasActiveSyncTransport: boolean
+  readonly hasActiveSparkAccount: boolean
+  readonly hasActiveCashRegisterAccount: boolean
+  readonly hasActiveFiatBankAccount: boolean
+  readonly hasDefaultPaymentMethod: boolean
+  readonly isDefaultPaymentMethodAvailable: boolean
+  readonly hasActiveFioPlugin: boolean
+}
+
+export interface ReadinessItem {
+  readonly id: ReadinessItemId
+  readonly title: TranslationKey
+  readonly description: TranslationKey
+  readonly completed: boolean
+  readonly actionLabel: TranslationKey
+  readonly actionTo: LinkProps["to"]
+}
+
+export function isPaymentMethodAvailable({
+  method,
+  hasActiveSparkAccount,
+  hasActiveCashRegisterAccount,
+  hasActiveFiatBankAccount,
+}: {
+  readonly method: DefaultPaymentMethod | null | undefined
+  readonly hasActiveSparkAccount: boolean
+  readonly hasActiveCashRegisterAccount: boolean
+  readonly hasActiveFiatBankAccount: boolean
+}) {
+  switch (method) {
+    case "spark":
+      return hasActiveSparkAccount
+    case "cashRegister":
+      return hasActiveCashRegisterAccount
+    case "iban":
+      return hasActiveFiatBankAccount
+    default:
+      return false
+  }
+}
+
+export function createReadinessItems({
+  hasRecoveryPhrase,
+  hasActiveSyncTransport,
+  hasActiveSparkAccount,
+  hasActiveCashRegisterAccount,
+  hasActiveFiatBankAccount,
+  hasDefaultPaymentMethod,
+  isDefaultPaymentMethodAvailable,
+  hasActiveFioPlugin,
+}: ReadinessStateInput): ReadonlyArray<ReadinessItem> {
+  const hasAnyPaymentMethod =
+    hasActiveSparkAccount ||
+    hasActiveCashRegisterAccount ||
+    hasActiveFiatBankAccount
+
+  return [
+    {
+      id: "recoveryPhrase",
+      title: "settings.readiness.item.recoveryPhrase.title",
+      description: "settings.readiness.item.recoveryPhrase.description",
+      completed: hasRecoveryPhrase,
+      actionLabel: "settings.readiness.item.recoveryPhrase.action",
+      actionTo: "/settings/security",
+    },
+    {
+      id: "sync",
+      title: "settings.readiness.item.sync.title",
+      description: "settings.readiness.item.sync.description",
+      completed: hasActiveSyncTransport,
+      actionLabel: "settings.readiness.item.sync.action",
+      actionTo: "/settings/security",
+    },
+    {
+      id: "paymentMethods",
+      title: "settings.readiness.item.paymentMethods.title",
+      description: "settings.readiness.item.paymentMethods.description",
+      completed: hasAnyPaymentMethod,
+      actionLabel: "settings.readiness.item.paymentMethods.action",
+      actionTo: "/settings/payment-accounts",
+    },
+    {
+      id: "defaultPaymentMethod",
+      title: "settings.readiness.item.defaultPaymentMethod.title",
+      description: "settings.readiness.item.defaultPaymentMethod.description",
+      completed: hasDefaultPaymentMethod && isDefaultPaymentMethodAvailable,
+      actionLabel: "settings.readiness.item.defaultPaymentMethod.action",
+      actionTo: "/settings/default-payment-method",
+    },
+    {
+      id: "bankAccount",
+      title: "settings.readiness.item.bankAccount.title",
+      description: "settings.readiness.item.bankAccount.description",
+      completed: hasActiveFiatBankAccount,
+      actionLabel: "settings.readiness.item.bankAccount.action",
+      actionTo: "/settings/payment-accounts",
+    },
+    {
+      id: "fioPlugin",
+      title: "settings.readiness.item.fioPlugin.title",
+      description: "settings.readiness.item.fioPlugin.description",
+      completed: !hasActiveFiatBankAccount || hasActiveFioPlugin,
+      actionLabel: "settings.readiness.item.fioPlugin.action",
+      actionTo: "/settings/fio-plugin",
+    },
+  ]
+}

--- a/src/features/settings/readiness/readiness-utils.ts
+++ b/src/features/settings/readiness/readiness-utils.ts
@@ -20,6 +20,7 @@ export interface ReadinessStateInput {
   readonly hasDefaultPaymentMethod: boolean
   readonly isDefaultPaymentMethodAvailable: boolean
   readonly hasActiveFioPlugin: boolean
+  readonly hasActiveFioPluginToken: boolean
 }
 
 export interface ReadinessItem {
@@ -63,6 +64,7 @@ export function createReadinessItems({
   hasDefaultPaymentMethod,
   isDefaultPaymentMethodAvailable,
   hasActiveFioPlugin,
+  hasActiveFioPluginToken,
 }: ReadinessStateInput): ReadonlyArray<ReadinessItem> {
   const hasAnyPaymentMethod =
     hasActiveSparkAccount ||
@@ -114,7 +116,9 @@ export function createReadinessItems({
       id: "fioPlugin",
       title: "settings.readiness.item.fioPlugin.title",
       description: "settings.readiness.item.fioPlugin.description",
-      completed: !hasActiveFiatBankAccount || hasActiveFioPlugin,
+      completed:
+        !hasActiveFiatBankAccount ||
+        (hasActiveFioPlugin && hasActiveFioPluginToken),
       actionLabel: "settings.readiness.item.fioPlugin.action",
       actionTo: "/settings/fio-plugin",
     },

--- a/src/i18n/cs.ts
+++ b/src/i18n/cs.ts
@@ -565,6 +565,41 @@ export const cs = {
   "settings.privacy.errorReporting.title": "Hlášení chyb",
   "settings.privacy.title": "Soukromí",
   "settings.privacyGroup": "SOUKROMÍ",
+  "settings.readiness.description":
+    "Checklist pro používání Payky se skutečnými zákazníky",
+  "settings.readiness.item.bankAccount.action": "Nastavit bankovní účet",
+  "settings.readiness.item.bankAccount.description":
+    "Bankovní QR platby potřebují povolený účet pro aktuální fiat měnu.",
+  "settings.readiness.item.bankAccount.title": "Bankovní účet",
+  "settings.readiness.item.defaultPaymentMethod.action":
+    "Vybrat výchozí metodu",
+  "settings.readiness.item.defaultPaymentMethod.description":
+    "Checkout se má otevírat s platební metodou, která je teď povolená.",
+  "settings.readiness.item.defaultPaymentMethod.title":
+    "Výchozí platební metoda",
+  "settings.readiness.item.fioPlugin.action": "Nastavit Fio",
+  "settings.readiness.item.fioPlugin.description":
+    "Automatické párování bankovních transakcí je připravené, když existuje aktivní Fio plugin pro bankovní platby.",
+  "settings.readiness.item.fioPlugin.title": "Fio synchronizace transakcí",
+  "settings.readiness.item.paymentMethods.action": "Spravovat platební účty",
+  "settings.readiness.item.paymentMethods.description":
+    "Povolte alespoň jeden způsob přijímání plateb v terminálu.",
+  "settings.readiness.item.paymentMethods.title": "Platební metody",
+  "settings.readiness.item.recoveryPhrase.action": "Otevřít bezpečnost",
+  "settings.readiness.item.recoveryPhrase.description":
+    "Aktivní účet má recovery phrase dostupnou pro zálohu.",
+  "settings.readiness.item.recoveryPhrase.title": "Recovery phrase",
+  "settings.readiness.item.sync.action": "Nastavit synchronizaci",
+  "settings.readiness.item.sync.description":
+    "Aktivní sync transport pomáhá zálohovat data terminálu mezi zařízeními.",
+  "settings.readiness.item.sync.title": "Synchronizace dat",
+  "settings.readiness.progress": "Hotovo {completed} z {total} položek",
+  "settings.readiness.status.completed": "Hotovo",
+  "settings.readiness.status.notCompleted": "Není hotovo",
+  "settings.readiness.summary.description":
+    "Použijte tento praktický checklist před přijímáním skutečných plateb.",
+  "settings.readiness.summary.title": "Checklist nastavení",
+  "settings.readiness.title": "Stav nastavení",
   "settings.security": "BEZPEČNOST A SOUKROMÍ",
   "settings.security.description": "Správa synchronizace a obnovy účtu",
   "settings.security.title": "Bezpečnost a synchronizace",

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -561,6 +561,40 @@ export const en = {
   "settings.privacy.errorReporting.title": "Error reporting",
   "settings.privacy.title": "Privacy",
   "settings.privacyGroup": "PRIVACY",
+  "settings.readiness.description":
+    "Checklist for using Payky with real customers",
+  "settings.readiness.item.bankAccount.action": "Set up bank account",
+  "settings.readiness.item.bankAccount.description":
+    "Bank QR payments need an enabled account for the current fiat currency.",
+  "settings.readiness.item.bankAccount.title": "Bank account",
+  "settings.readiness.item.defaultPaymentMethod.action": "Choose default",
+  "settings.readiness.item.defaultPaymentMethod.description":
+    "Checkout should open with a payment method that is enabled now.",
+  "settings.readiness.item.defaultPaymentMethod.title":
+    "Default payment method",
+  "settings.readiness.item.fioPlugin.action": "Configure Fio",
+  "settings.readiness.item.fioPlugin.description":
+    "Automatic bank transaction matching is ready when an active Fio plugin exists for bank payments.",
+  "settings.readiness.item.fioPlugin.title": "Fio transaction sync",
+  "settings.readiness.item.paymentMethods.action": "Manage payment accounts",
+  "settings.readiness.item.paymentMethods.description":
+    "Enable at least one way to accept payments in the terminal.",
+  "settings.readiness.item.paymentMethods.title": "Payment methods",
+  "settings.readiness.item.recoveryPhrase.action": "Open security settings",
+  "settings.readiness.item.recoveryPhrase.description":
+    "The active account has a recovery phrase available for backup.",
+  "settings.readiness.item.recoveryPhrase.title": "Recovery phrase",
+  "settings.readiness.item.sync.action": "Configure sync",
+  "settings.readiness.item.sync.description":
+    "An active sync transport helps keep the terminal data backed up across devices.",
+  "settings.readiness.item.sync.title": "Data sync",
+  "settings.readiness.progress": "{completed} of {total} items complete",
+  "settings.readiness.status.completed": "Completed",
+  "settings.readiness.status.notCompleted": "Not completed",
+  "settings.readiness.summary.description":
+    "Use this practical checklist before accepting real payments.",
+  "settings.readiness.summary.title": "Setup checklist",
+  "settings.readiness.title": "Setup Status",
   "settings.security": "SECURITY & PRIVACY",
   "settings.security.description": "Manage sync transports and recovery access",
   "settings.security.title": "Security & Sync",

--- a/src/i18n/sk.ts
+++ b/src/i18n/sk.ts
@@ -565,6 +565,41 @@ export const sk = {
   "settings.privacy.errorReporting.title": "Hlásenie chýb",
   "settings.privacy.title": "Súkromie",
   "settings.privacyGroup": "SÚKROMIE",
+  "settings.readiness.description":
+    "Checklist pre používanie Payky so skutočnými zákazníkmi",
+  "settings.readiness.item.bankAccount.action": "Nastaviť bankový účet",
+  "settings.readiness.item.bankAccount.description":
+    "Bankové QR platby potrebujú povolený účet pre aktuálnu fiat menu.",
+  "settings.readiness.item.bankAccount.title": "Bankový účet",
+  "settings.readiness.item.defaultPaymentMethod.action":
+    "Vybrať predvolenú metódu",
+  "settings.readiness.item.defaultPaymentMethod.description":
+    "Checkout sa má otvárať s platobnou metódou, ktorá je teraz povolená.",
+  "settings.readiness.item.defaultPaymentMethod.title":
+    "Predvolená platobná metóda",
+  "settings.readiness.item.fioPlugin.action": "Nastaviť Fio",
+  "settings.readiness.item.fioPlugin.description":
+    "Automatické párovanie bankových transakcií je pripravené, keď existuje aktívny Fio plugin pre bankové platby.",
+  "settings.readiness.item.fioPlugin.title": "Fio synchronizácia transakcií",
+  "settings.readiness.item.paymentMethods.action": "Spravovať platobné účty",
+  "settings.readiness.item.paymentMethods.description":
+    "Povoľte aspoň jeden spôsob prijímania platieb v termináli.",
+  "settings.readiness.item.paymentMethods.title": "Platobné metódy",
+  "settings.readiness.item.recoveryPhrase.action": "Otvoriť bezpečnosť",
+  "settings.readiness.item.recoveryPhrase.description":
+    "Aktívny účet má recovery phrase dostupnú pre zálohu.",
+  "settings.readiness.item.recoveryPhrase.title": "Recovery phrase",
+  "settings.readiness.item.sync.action": "Nastaviť synchronizáciu",
+  "settings.readiness.item.sync.description":
+    "Aktívny sync transport pomáha zálohovať dáta terminálu medzi zariadeniami.",
+  "settings.readiness.item.sync.title": "Synchronizácia dát",
+  "settings.readiness.progress": "Hotovo {completed} z {total} položiek",
+  "settings.readiness.status.completed": "Hotovo",
+  "settings.readiness.status.notCompleted": "Nie je hotovo",
+  "settings.readiness.summary.description":
+    "Použite tento praktický checklist pred prijímaním skutočných platieb.",
+  "settings.readiness.summary.title": "Checklist nastavenia",
+  "settings.readiness.title": "Stav nastavenia",
   "settings.security": "BEZPEČNOSŤ A SÚKROMIE",
   "settings.security.description": "Správa synchronizácie a obnovy účtu",
   "settings.security.title": "Bezpečnosť a synchronizácia",

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -21,6 +21,7 @@ import { Route as TerminalSettingsIndexRouteImport } from './routes/_terminal.se
 import { Route as TerminalSettingsWithdrawRouteImport } from './routes/_terminal.settings.withdraw'
 import { Route as TerminalSettingsThemeRouteImport } from './routes/_terminal.settings.theme'
 import { Route as TerminalSettingsSecurityRouteImport } from './routes/_terminal.settings.security'
+import { Route as TerminalSettingsReadinessRouteImport } from './routes/_terminal.settings.readiness'
 import { Route as TerminalSettingsPrivacyRouteImport } from './routes/_terminal.settings.privacy'
 import { Route as TerminalSettingsPaymentNumberSeriesRouteImport } from './routes/_terminal.settings.payment-number-series'
 import { Route as TerminalSettingsPaymentAccountsRouteImport } from './routes/_terminal.settings.payment-accounts'
@@ -101,6 +102,12 @@ const TerminalSettingsSecurityRoute =
   TerminalSettingsSecurityRouteImport.update({
     id: '/security',
     path: '/security',
+    getParentRoute: () => TerminalSettingsRoute,
+  } as any)
+const TerminalSettingsReadinessRoute =
+  TerminalSettingsReadinessRouteImport.update({
+    id: '/readiness',
+    path: '/readiness',
     getParentRoute: () => TerminalSettingsRoute,
   } as any)
 const TerminalSettingsPrivacyRoute = TerminalSettingsPrivacyRouteImport.update({
@@ -244,6 +251,7 @@ export interface FileRoutesByFullPath {
   '/settings/payment-accounts': typeof TerminalSettingsPaymentAccountsRoute
   '/settings/payment-number-series': typeof TerminalSettingsPaymentNumberSeriesRoute
   '/settings/privacy': typeof TerminalSettingsPrivacyRoute
+  '/settings/readiness': typeof TerminalSettingsReadinessRoute
   '/settings/security': typeof TerminalSettingsSecurityRoute
   '/settings/theme': typeof TerminalSettingsThemeRoute
   '/settings/withdraw': typeof TerminalSettingsWithdrawRoute
@@ -275,6 +283,7 @@ export interface FileRoutesByTo {
   '/settings/payment-accounts': typeof TerminalSettingsPaymentAccountsRoute
   '/settings/payment-number-series': typeof TerminalSettingsPaymentNumberSeriesRoute
   '/settings/privacy': typeof TerminalSettingsPrivacyRoute
+  '/settings/readiness': typeof TerminalSettingsReadinessRoute
   '/settings/security': typeof TerminalSettingsSecurityRoute
   '/settings/theme': typeof TerminalSettingsThemeRoute
   '/settings/withdraw': typeof TerminalSettingsWithdrawRoute
@@ -310,6 +319,7 @@ export interface FileRoutesById {
   '/_terminal/settings/payment-accounts': typeof TerminalSettingsPaymentAccountsRoute
   '/_terminal/settings/payment-number-series': typeof TerminalSettingsPaymentNumberSeriesRoute
   '/_terminal/settings/privacy': typeof TerminalSettingsPrivacyRoute
+  '/_terminal/settings/readiness': typeof TerminalSettingsReadinessRoute
   '/_terminal/settings/security': typeof TerminalSettingsSecurityRoute
   '/_terminal/settings/theme': typeof TerminalSettingsThemeRoute
   '/_terminal/settings/withdraw': typeof TerminalSettingsWithdrawRoute
@@ -345,6 +355,7 @@ export interface FileRouteTypes {
     | '/settings/payment-accounts'
     | '/settings/payment-number-series'
     | '/settings/privacy'
+    | '/settings/readiness'
     | '/settings/security'
     | '/settings/theme'
     | '/settings/withdraw'
@@ -376,6 +387,7 @@ export interface FileRouteTypes {
     | '/settings/payment-accounts'
     | '/settings/payment-number-series'
     | '/settings/privacy'
+    | '/settings/readiness'
     | '/settings/security'
     | '/settings/theme'
     | '/settings/withdraw'
@@ -410,6 +422,7 @@ export interface FileRouteTypes {
     | '/_terminal/settings/payment-accounts'
     | '/_terminal/settings/payment-number-series'
     | '/_terminal/settings/privacy'
+    | '/_terminal/settings/readiness'
     | '/_terminal/settings/security'
     | '/_terminal/settings/theme'
     | '/_terminal/settings/withdraw'
@@ -510,6 +523,13 @@ declare module '@tanstack/react-router' {
       path: '/security'
       fullPath: '/settings/security'
       preLoaderRoute: typeof TerminalSettingsSecurityRouteImport
+      parentRoute: typeof TerminalSettingsRoute
+    }
+    '/_terminal/settings/readiness': {
+      id: '/_terminal/settings/readiness'
+      path: '/readiness'
+      fullPath: '/settings/readiness'
+      preLoaderRoute: typeof TerminalSettingsReadinessRouteImport
       parentRoute: typeof TerminalSettingsRoute
     }
     '/_terminal/settings/privacy': {
@@ -687,6 +707,7 @@ interface TerminalSettingsRouteChildren {
   TerminalSettingsPaymentAccountsRoute: typeof TerminalSettingsPaymentAccountsRoute
   TerminalSettingsPaymentNumberSeriesRoute: typeof TerminalSettingsPaymentNumberSeriesRoute
   TerminalSettingsPrivacyRoute: typeof TerminalSettingsPrivacyRoute
+  TerminalSettingsReadinessRoute: typeof TerminalSettingsReadinessRoute
   TerminalSettingsSecurityRoute: typeof TerminalSettingsSecurityRoute
   TerminalSettingsThemeRoute: typeof TerminalSettingsThemeRoute
   TerminalSettingsWithdrawRoute: typeof TerminalSettingsWithdrawRoute
@@ -710,6 +731,7 @@ const TerminalSettingsRouteChildren: TerminalSettingsRouteChildren = {
   TerminalSettingsPaymentNumberSeriesRoute:
     TerminalSettingsPaymentNumberSeriesRoute,
   TerminalSettingsPrivacyRoute: TerminalSettingsPrivacyRoute,
+  TerminalSettingsReadinessRoute: TerminalSettingsReadinessRoute,
   TerminalSettingsSecurityRoute: TerminalSettingsSecurityRoute,
   TerminalSettingsThemeRoute: TerminalSettingsThemeRoute,
   TerminalSettingsWithdrawRoute: TerminalSettingsWithdrawRoute,

--- a/src/routes/_terminal.settings.index.tsx
+++ b/src/routes/_terminal.settings.index.tsx
@@ -11,6 +11,7 @@ import {
   Info,
   Landmark,
   Languages,
+  ListChecks,
   Lock,
   Plug,
   ReceiptText,
@@ -64,6 +65,12 @@ const terminalSettings: ReadonlyArray<SettingRow> = [
 ]
 
 const accountSettings: ReadonlyArray<SettingRow> = [
+  {
+    icon: ListChecks,
+    title: "settings.readiness.title",
+    description: "settings.readiness.description",
+    to: "/settings/readiness",
+  },
   {
     icon: UserRound,
     title: "settings.accounts.nav.title",

--- a/src/routes/_terminal.settings.readiness.tsx
+++ b/src/routes/_terminal.settings.readiness.tsx
@@ -1,0 +1,155 @@
+import { sqliteTrue } from "@evolu/common"
+import { createFileRoute, Link } from "@tanstack/react-router"
+import { useAtomValue } from "jotai"
+import { CheckCircle2, CircleAlert } from "lucide-react"
+
+import { accountAtom } from "@/atoms/account.ts"
+import { FadeHeader } from "@/components/fade-header.tsx"
+import { Badge } from "@/components/ui/badge.tsx"
+import { Button } from "@/components/ui/button.tsx"
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card.tsx"
+import {
+  cashRegisterAccountQuery,
+  fiatBankAccountQuery,
+  sparkAccountQuery,
+} from "@/core/modules/account/account-queries.ts"
+import { settingsQuery } from "@/core/modules/app-settings/app-settings-queries.ts"
+import { getDefaultPaymentMethod } from "@/core/modules/app-settings/app-settings-utils.ts"
+import { fiatBankAccountFioPluginQuery } from "@/core/modules/fio-plugin/fio-plugin-queries.ts"
+import { FiatCurrency } from "@/core/modules/shared/schema.ts"
+import {
+  createReadinessItems,
+  isPaymentMethodAvailable,
+} from "@/features/settings/readiness/readiness-utils.ts"
+import { accountTransportsQuery } from "@/features/settings/security/transport-toggle-list.tsx"
+import { useDeviceEvoluQuery } from "@/hooks/use-device-evolu-query.ts"
+import { useEvoluQuery } from "@/hooks/use-evolu-query.ts"
+import { useTranslation } from "@/hooks/use-translation.ts"
+
+export const Route = createFileRoute("/_terminal/settings/readiness")({
+  component: ReadinessPage,
+  staticData: {
+    terminalLayout: {
+      viewportClassName: "px-5 py-6",
+    },
+  },
+})
+
+function ReadinessPage() {
+  const { t } = useTranslation()
+  const account = useAtomValue(accountAtom)
+  const { data: transports } = useDeviceEvoluQuery(
+    accountTransportsQuery(account.id)
+  )
+  const { data: settingsData } = useEvoluQuery(settingsQuery)
+  const { data: fiatBankAccountData } = useEvoluQuery(fiatBankAccountQuery)
+  const { data: sparkAccountData } = useEvoluQuery(sparkAccountQuery)
+  const { data: cashRegisterAccountData } = useEvoluQuery(
+    cashRegisterAccountQuery
+  )
+  const { data: fioPluginData } = useEvoluQuery(fiatBankAccountFioPluginQuery)
+  const [settings] = settingsData
+  const [fiatBankAccount] = fiatBankAccountData
+  const [sparkAccount] = sparkAccountData
+  const [cashRegisterAccount] = cashRegisterAccountData
+  const [fioPlugin] = fioPluginData
+  const fiatCurrency = settings?.fiatCurrency ?? FiatCurrency.CZK
+  const hasActiveFiatBankAccount =
+    fiatBankAccount !== undefined &&
+    fiatBankAccount.isDeleted !== 1 &&
+    fiatBankAccount.currency === fiatCurrency
+  const hasActiveSparkAccount =
+    sparkAccount !== undefined && sparkAccount.isDeleted !== 1
+  const hasActiveCashRegisterAccount =
+    cashRegisterAccount !== undefined &&
+    cashRegisterAccount.isDeleted !== 1 &&
+    cashRegisterAccount.currency === fiatCurrency
+  const defaultPaymentMethod = getDefaultPaymentMethod(
+    settings?.defaultPaymentMethod
+  )
+  const items = createReadinessItems({
+    hasRecoveryPhrase: account.mnemonic.trim().length > 0,
+    hasActiveSyncTransport: transports.some(
+      (transport) => transport.isActive === sqliteTrue
+    ),
+    hasActiveSparkAccount,
+    hasActiveCashRegisterAccount,
+    hasActiveFiatBankAccount,
+    hasDefaultPaymentMethod: settings?.defaultPaymentMethod != null,
+    isDefaultPaymentMethodAvailable: isPaymentMethodAvailable({
+      method: defaultPaymentMethod,
+      hasActiveSparkAccount,
+      hasActiveCashRegisterAccount,
+      hasActiveFiatBankAccount,
+    }),
+    hasActiveFioPlugin: fioPlugin?.isActive === sqliteTrue,
+  })
+  const completedCount = items.filter((item) => item.completed).length
+
+  return (
+    <>
+      <div className="h-6" />
+      <FadeHeader title={t("settings.readiness.title")} />
+      <Card>
+        <CardHeader>
+          <CardTitle>{t("settings.readiness.summary.title")}</CardTitle>
+          <CardDescription>
+            {t("settings.readiness.summary.description")}
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="flex flex-col gap-4">
+          <div className="text-sm text-muted-foreground">
+            {t("settings.readiness.progress", {
+              completed: completedCount.toString(),
+              total: items.length.toString(),
+            })}
+          </div>
+          <ul className="flex flex-col gap-3">
+            {items.map((item) => (
+              <li
+                key={item.id}
+                className="flex items-start gap-3 rounded-lg border p-3"
+              >
+                {item.completed ? (
+                  <CheckCircle2 className="mt-0.5 size-5 shrink-0 text-green-600" />
+                ) : (
+                  <CircleAlert className="mt-0.5 size-5 shrink-0 text-amber-600" />
+                )}
+                <div className="flex min-w-0 flex-1 flex-col gap-2">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <span className="font-medium">{t(item.title)}</span>
+                    <Badge variant={item.completed ? "secondary" : "outline"}>
+                      {item.completed
+                        ? t("settings.readiness.status.completed")
+                        : t("settings.readiness.status.notCompleted")}
+                    </Badge>
+                  </div>
+                  <p className="text-sm text-muted-foreground">
+                    {t(item.description)}
+                  </p>
+                  {!item.completed && (
+                    <Button
+                      className="w-fit"
+                      variant="outline"
+                      size="sm"
+                      nativeButton={false}
+                      render={<Link to={item.actionTo} />}
+                    >
+                      {t(item.actionLabel)}
+                    </Button>
+                  )}
+                </div>
+              </li>
+            ))}
+          </ul>
+        </CardContent>
+      </Card>
+    </>
+  )
+}

--- a/src/routes/_terminal.settings.readiness.tsx
+++ b/src/routes/_terminal.settings.readiness.tsx
@@ -1,4 +1,4 @@
-import { sqliteTrue } from "@evolu/common"
+import { createIdFromString, sqliteTrue } from "@evolu/common"
 import { createFileRoute, Link } from "@tanstack/react-router"
 import { useAtomValue } from "jotai"
 import { CheckCircle2, CircleAlert } from "lucide-react"
@@ -21,7 +21,10 @@ import {
 } from "@/core/modules/account/account-queries.ts"
 import { settingsQuery } from "@/core/modules/app-settings/app-settings-queries.ts"
 import { getDefaultPaymentMethod } from "@/core/modules/app-settings/app-settings-utils.ts"
-import { fiatBankAccountFioPluginQuery } from "@/core/modules/fio-plugin/fio-plugin-queries.ts"
+import {
+  fiatBankAccountFioPluginQuery,
+  fioPluginTokensByPluginIdQuery,
+} from "@/core/modules/fio-plugin/fio-plugin-queries.ts"
 import { FiatCurrency } from "@/core/modules/shared/schema.ts"
 import {
   createReadinessItems,
@@ -41,6 +44,10 @@ export const Route = createFileRoute("/_terminal/settings/readiness")({
   },
 })
 
+const fioPluginTokenPlaceholderId = createIdFromString<"FioPlugin">(
+  "payky-readiness-fio-plugin-token-placeholder"
+)
+
 function ReadinessPage() {
   const { t } = useTranslation()
   const account = useAtomValue(accountAtom)
@@ -59,6 +66,9 @@ function ReadinessPage() {
   const [sparkAccount] = sparkAccountData
   const [cashRegisterAccount] = cashRegisterAccountData
   const [fioPlugin] = fioPluginData
+  const { data: fioPluginTokens } = useEvoluQuery(
+    fioPluginTokensByPluginIdQuery(fioPlugin?.id ?? fioPluginTokenPlaceholderId)
+  )
   const fiatCurrency = settings?.fiatCurrency ?? FiatCurrency.CZK
   const hasActiveFiatBankAccount =
     fiatBankAccount !== undefined &&
@@ -89,6 +99,7 @@ function ReadinessPage() {
       hasActiveFiatBankAccount,
     }),
     hasActiveFioPlugin: fioPlugin?.isActive === sqliteTrue,
+    hasActiveFioPluginToken: fioPluginTokens.length > 0,
   })
   const completedCount = items.filter((item) => item.completed).length
 


### PR DESCRIPTION
## Summary
- add a localized Settings > Setup Status screen with checklist-style readiness states
- compose live app/device state for recovery phrase, sync transport, payment accounts, default method, bank account, and Fio readiness
- add Settings navigation and helper coverage for complete/incomplete checklist states

Fixes #32

## Verification
- bun run check:lint
- bun run check:ts
- bun run build
- bun run check:tests src/features/settings/readiness/readiness-utils.test.ts

## Known validation issue
- bun run check:tests currently fails in this environment outside this change because Vitest runs on Node v22.22.3 where Promise.try and AsyncDisposableStack are unavailable; the new readiness test passes in isolation.