### PR TITLE
fix: allow retrying payment method preparation

### DIFF
--- a/src/features/payment-wait/payment-method-preparation.test.ts
+++ b/src/features/payment-wait/payment-method-preparation.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, test } from "vitest"
+import {
+  clearPaymentMethodPreparation,
+  createPaymentMethodPreparationRunner,
+  failPaymentMethodPreparation,
+  requestPaymentMethodPreparation,
+  retryPaymentMethodPreparation,
+} from "./payment-method-preparation.ts"
+
+const sparkKey = "payment-1:spark:account-1"
+const ibanKey = "payment-1:iban:account-2"
+
+describe("payment method preparation state", () => {
+  test("retains a failed preparation until retry", () => {
+    const requested = requestPaymentMethodPreparation({}, sparkKey)
+    const error = new Error("prepare failed")
+    const failed = failPaymentMethodPreparation(
+      requested.state,
+      sparkKey,
+      error
+    )
+
+    expect(failed[sparkKey]).toEqual({ status: "failed", error })
+    expect(requestPaymentMethodPreparation(failed, sparkKey)).toEqual({
+      state: failed,
+      shouldPrepare: false,
+    })
+  })
+
+  test("retry permits exactly one reattempt", () => {
+    const failed = failPaymentMethodPreparation(
+      requestPaymentMethodPreparation({}, sparkKey).state,
+      sparkKey,
+      new Error("prepare failed")
+    )
+    const retried = retryPaymentMethodPreparation(failed, sparkKey)
+
+    expect(retried.shouldPrepare).toBe(true)
+    expect(retried.state[sparkKey]).toEqual({ status: "preparing" })
+    expect(retryPaymentMethodPreparation(retried.state, sparkKey)).toEqual({
+      state: retried.state,
+      shouldPrepare: false,
+    })
+  })
+
+  test("persistent failure does not request another attempt", () => {
+    const firstAttempt = requestPaymentMethodPreparation({}, sparkKey)
+    const firstFailure = failPaymentMethodPreparation(
+      firstAttempt.state,
+      sparkKey,
+      new Error("still failing")
+    )
+    const automaticRequest = requestPaymentMethodPreparation(
+      firstFailure,
+      sparkKey
+    )
+
+    expect(firstAttempt.shouldPrepare).toBe(true)
+    expect(automaticRequest.shouldPrepare).toBe(false)
+    expect(automaticRequest.state).toBe(firstFailure)
+  })
+
+  test("deduplicates replayed attempts and permits one retry after failure", async () => {
+    const runner = createPaymentMethodPreparationRunner()
+    let rejectAttempt: ((error: Error) => void) | undefined
+    let attempts = 0
+    const prepare = () => {
+      attempts += 1
+      return new Promise<void>((_resolve, reject) => {
+        rejectAttempt = reject
+      })
+    }
+
+    const firstRun = runner.run(sparkKey, prepare)
+    const replayedRun = runner.run(sparkKey, prepare)
+
+    expect(attempts).toBe(1)
+    expect(replayedRun).toBe(firstRun)
+
+    rejectAttempt?.(new Error("still failing"))
+    await expect(firstRun).rejects.toThrow("still failing")
+
+    const retryRun = runner.run(sparkKey, prepare)
+    const replayedRetryRun = runner.run(sparkKey, prepare)
+
+    expect(attempts).toBe(2)
+    expect(replayedRetryRun).toBe(retryRun)
+
+    rejectAttempt?.(new Error("still failing"))
+    await expect(retryRun).rejects.toThrow("still failing")
+  })
+
+  test("keeps method keys isolated", () => {
+    const sparkAttempt = requestPaymentMethodPreparation({}, sparkKey)
+    const sparkFailure = failPaymentMethodPreparation(
+      sparkAttempt.state,
+      sparkKey,
+      new Error("spark failed")
+    )
+    const ibanAttempt = requestPaymentMethodPreparation(sparkFailure, ibanKey)
+
+    expect(ibanAttempt.shouldPrepare).toBe(true)
+    expect(ibanAttempt.state[sparkKey]?.status).toBe("failed")
+    expect(ibanAttempt.state[ibanKey]).toEqual({ status: "preparing" })
+
+    const cleared = clearPaymentMethodPreparation(ibanAttempt.state, ibanKey)
+    expect(cleared[sparkKey]?.status).toBe("failed")
+    expect(cleared[ibanKey]).toBeUndefined()
+  })
+})

--- a/src/features/payment-wait/payment-method-preparation.ts
+++ b/src/features/payment-wait/payment-method-preparation.ts
@@ -1,0 +1,90 @@
+export type PaymentMethodPreparationStatus =
+  | { readonly status: "preparing" }
+  | { readonly status: "failed"; readonly error: unknown }
+
+export type PaymentMethodPreparationState = Readonly<
+  Record<string, PaymentMethodPreparationStatus>
+>
+
+interface PaymentMethodPreparationTransition {
+  readonly state: PaymentMethodPreparationState
+  readonly shouldPrepare: boolean
+}
+
+interface PaymentMethodPreparationRunner {
+  run(key: string, prepare: () => Promise<void>): Promise<void>
+}
+
+export const createPaymentMethodPreparationRunner =
+  (): PaymentMethodPreparationRunner => {
+    const inFlightAttempts = new Map<string, Promise<void>>()
+
+    return {
+      run(key, prepare) {
+        const inFlightAttempt = inFlightAttempts.get(key)
+        if (inFlightAttempt !== undefined) return inFlightAttempt
+
+        let preparation: Promise<void>
+        try {
+          preparation = prepare()
+        } catch (error) {
+          preparation = Promise.reject(error)
+        }
+
+        const attempt = preparation.finally(() => {
+          if (inFlightAttempts.get(key) === attempt) {
+            inFlightAttempts.delete(key)
+          }
+        })
+        inFlightAttempts.set(key, attempt)
+        return attempt
+      },
+    }
+  }
+
+export const requestPaymentMethodPreparation = (
+  state: PaymentMethodPreparationState,
+  key: string
+): PaymentMethodPreparationTransition => {
+  if (state[key] !== undefined) {
+    return { state, shouldPrepare: false }
+  }
+
+  return {
+    state: { ...state, [key]: { status: "preparing" } },
+    shouldPrepare: true,
+  }
+}
+
+export const retryPaymentMethodPreparation = (
+  state: PaymentMethodPreparationState,
+  key: string
+): PaymentMethodPreparationTransition => {
+  if (state[key]?.status !== "failed") {
+    return { state, shouldPrepare: false }
+  }
+
+  return {
+    state: { ...state, [key]: { status: "preparing" } },
+    shouldPrepare: true,
+  }
+}
+
+export const failPaymentMethodPreparation = (
+  state: PaymentMethodPreparationState,
+  key: string,
+  error: unknown
+): PaymentMethodPreparationState => ({
+  ...state,
+  [key]: { status: "failed", error },
+})
+
+export const clearPaymentMethodPreparation = (
+  state: PaymentMethodPreparationState,
+  key: string
+): PaymentMethodPreparationState => {
+  if (state[key] === undefined) return state
+
+  const { [key]: _cleared, ...remaining } = state
+  return remaining
+}

--- a/src/i18n/cs.ts
+++ b/src/i18n/cs.ts
@@ -136,6 +136,7 @@ export const cs = {
   "paymentWait.paid": "Platba přijata",
   "paymentWait.pay": "Zaplatit",
   "paymentWait.prepareError": "Tuto platební metodu se nepodařilo připravit.",
+  "paymentWait.prepareRetry": "Zkusit platební metodu znovu",
   "paymentWait.preparing.cash": "Připravuji hotovostní platbu...",
   "paymentWait.preparing.iban": "Připravuji bankovní QR platbu...",
   "paymentWait.preparing.spark": "Připravuji Lightning žádost...",

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -135,6 +135,7 @@ export const en = {
   "paymentWait.paid": "Payment received",
   "paymentWait.pay": "Pay",
   "paymentWait.prepareError": "Could not prepare this payment method.",
+  "paymentWait.prepareRetry": "Retry payment method",
   "paymentWait.preparing.cash": "Preparing cash payment...",
   "paymentWait.preparing.iban": "Preparing bank QR payment...",
   "paymentWait.preparing.spark": "Preparing Lightning request...",

--- a/src/i18n/sk.ts
+++ b/src/i18n/sk.ts
@@ -137,6 +137,7 @@ export const sk = {
   "paymentWait.paid": "Platba prijatá",
   "paymentWait.pay": "Zaplatiť",
   "paymentWait.prepareError": "Túto platobnú metódu sa nepodarilo pripraviť.",
+  "paymentWait.prepareRetry": "Skúsiť platobnú metódu znova",
   "paymentWait.preparing.cash": "Pripravujem hotovostnú platbu...",
   "paymentWait.preparing.iban": "Pripravujem bankovú QR platbu...",
   "paymentWait.preparing.spark": "Pripravujem Lightning žiadosť...",

--- a/src/routes/_terminal.payment_.$paymentId.tsx
+++ b/src/routes/_terminal.payment_.$paymentId.tsx
@@ -12,9 +12,9 @@ import { QRCodeSVG } from "qrcode.react"
 import {
   type ReactNode,
   Suspense,
+  useCallback,
   useEffect,
   useMemo,
-  useRef,
   useState,
 } from "react"
 import { toast } from "sonner"
@@ -48,6 +48,14 @@ import {
 } from "@/core/modules/payment/payment-iban-qr-payload-utils.ts"
 import { PaymentId } from "@/core/modules/payment/payment-types.ts"
 import { type BankQrFormat, Currency } from "@/core/modules/shared/schema.ts"
+import {
+  clearPaymentMethodPreparation,
+  createPaymentMethodPreparationRunner,
+  failPaymentMethodPreparation,
+  type PaymentMethodPreparationState,
+  requestPaymentMethodPreparation,
+  retryPaymentMethodPreparation,
+} from "@/features/payment-wait/payment-method-preparation.ts"
 import { useAppRun } from "@/hooks/use-app-run.ts"
 import { useConsole } from "@/hooks/use-console.ts"
 import { useEvoluQuery } from "@/hooks/use-evolu-query.ts"
@@ -241,12 +249,11 @@ function PaymentWaitingRequest({
   const [cashPaymentPending, setCashPaymentPending] = useState(false)
   const [cashPaymentErrorKey, setCashPaymentErrorKey] =
     useState<TranslationKey | null>(null)
-  const [preparePaymentErrorMethods, setPreparePaymentErrorMethods] = useState<
-    ReadonlySet<PaymentMethodTab>
-  >(() => new Set())
-  const [preparingPaymentMethods, setPreparingPaymentMethods] = useState<
-    ReadonlySet<PaymentMethodTab>
-  >(() => new Set())
+  const [paymentMethodPreparationState, setPaymentMethodPreparationState] =
+    useState<PaymentMethodPreparationState>({})
+  const [paymentMethodPreparationRunner] = useState(
+    createPaymentMethodPreparationRunner
+  )
   const [successVisible, setSuccessVisible] = useState(false)
   const [selectedPaymentMethod, setSelectedPaymentMethod] =
     useState<PaymentMethodTab | null>(null)
@@ -257,7 +264,6 @@ function PaymentWaitingRequest({
     release: releaseWakeLock,
     request: requestWakeLock,
   } = useWakeLock()
-  const preparePaymentMethodKeysRef = useRef(new Set<string>())
   const query = useMemo(() => paymentRequestQuery(paymentId), [paymentId])
   const claimsQuery = useMemo(() => paymentClaimsQuery(paymentId), [paymentId])
   const { data: payments } = useEvoluQuery(query)
@@ -376,16 +382,71 @@ function PaymentWaitingRequest({
     defaultPaymentMethodOption ??
     orderedPaymentMethods[0] ??
     null
+  const activePreparationKey =
+    activePaymentMethod === null
+      ? null
+      : `${paymentId}:${activePaymentMethod.id}:${activePaymentMethod.accountId}`
+  const activePreparationStatus =
+    activePreparationKey === null
+      ? undefined
+      : paymentMethodPreparationState[activePreparationKey]
   const activePreparingPaymentMethodKey =
     activePaymentMethod !== null &&
-    preparingPaymentMethods.has(activePaymentMethod.id)
+    activePreparationStatus?.status === "preparing"
       ? preparingPaymentMethodKeys[activePaymentMethod.id]
       : null
   const activePreparePaymentErrorKey =
-    activePaymentMethod !== null &&
-    preparePaymentErrorMethods.has(activePaymentMethod.id)
+    activePreparationStatus?.status === "failed"
       ? "paymentWait.prepareError"
       : null
+  const activePaymentMethodIsPrepared =
+    activePaymentMethod !== null &&
+    payment !== undefined &&
+    ((activePaymentMethod.id === "spark" &&
+      (payment.lnInvoice !== null || payment.sparkInvoice !== null)) ||
+      (activePaymentMethod.id === "iban" && payment.ibanAccountId !== null) ||
+      (activePaymentMethod.id === "cash" &&
+        payment.cashRegisterAccountId !== null &&
+        payment.cashRegisterAccountId !== undefined))
+
+  const runPaymentMethodPreparation = useCallback(
+    async (
+      method: Pick<PaymentMethodOption, "accountId" | "kind">,
+      preparationKey: string
+    ) => {
+      try {
+        await using run = appRun()
+
+        const result = await run(
+          preparePaymentMethod({
+            paymentId,
+            ...(method.kind === "cashRegister"
+              ? { cashRegister: { accountId: method.accountId } }
+              : {}),
+            ...(method.kind === "iban"
+              ? { bank: { accountId: method.accountId } }
+              : {}),
+            ...(method.kind === "spark"
+              ? { spark: { accountId: method.accountId } }
+              : {}),
+          })
+        )
+
+        if (!result.ok) {
+          console.error("Failed to prepare payment method", result.error)
+          setPaymentMethodPreparationState((state) =>
+            failPaymentMethodPreparation(state, preparationKey, result.error)
+          )
+        }
+      } catch (error) {
+        console.error("Failed to prepare payment method", error)
+        setPaymentMethodPreparationState((state) =>
+          failPaymentMethodPreparation(state, preparationKey, error)
+        )
+      }
+    },
+    [appRun, console, paymentId]
+  )
 
   useEffect(() => {
     if (!wakeLockEnabled) {
@@ -423,89 +484,61 @@ function PaymentWaitingRequest({
     if (
       payment === undefined ||
       activePaymentMethod === null ||
-      preparingPaymentMethods.has(activePaymentMethod.id) ||
+      activePreparationKey === null ||
       isPaid
     ) {
       return
     }
 
-    const isPrepared =
-      (activePaymentMethod.id === "spark" &&
-        (payment.lnInvoice !== null || payment.sparkInvoice !== null)) ||
-      (activePaymentMethod.id === "iban" && payment.ibanAccountId !== null) ||
-      (activePaymentMethod.id === "cash" &&
-        payment.cashRegisterAccountId !== null &&
-        payment.cashRegisterAccountId !== undefined)
-    if (isPrepared) return
-
-    const prepareKey = `${paymentId}:${activePaymentMethod.id}:${activePaymentMethod.accountId}`
-    if (preparePaymentMethodKeysRef.current.has(prepareKey)) return
-    preparePaymentMethodKeysRef.current.add(prepareKey)
-
-    const prepare = async () => {
-      setPreparePaymentErrorMethods((methods) => {
-        const nextMethods = new Set(methods)
-        nextMethods.delete(activePaymentMethod.id)
-        return nextMethods
-      })
-      setPreparingPaymentMethods((methods) =>
-        new Set(methods).add(activePaymentMethod.id)
+    if (activePaymentMethodIsPrepared) {
+      setPaymentMethodPreparationState((state) =>
+        clearPaymentMethodPreparation(state, activePreparationKey)
       )
-      try {
-        await using run = appRun()
-
-        const result = await run(
-          preparePaymentMethod({
-            paymentId,
-            ...(activePaymentMethod.kind === "cashRegister"
-              ? {
-                  cashRegister: {
-                    accountId: activePaymentMethod.accountId,
-                  },
-                }
-              : {}),
-            ...(activePaymentMethod.kind === "iban"
-              ? {
-                  bank: {
-                    accountId: activePaymentMethod.accountId,
-                  },
-                }
-              : {}),
-            ...(activePaymentMethod.kind === "spark"
-              ? {
-                  spark: {
-                    accountId: activePaymentMethod.accountId,
-                  },
-                }
-              : {}),
-          })
-        )
-
-        if (!result.ok) {
-          console.error("Failed to prepare payment method", result.error)
-          setPreparePaymentErrorMethods((methods) =>
-            new Set(methods).add(activePaymentMethod.id)
-          )
-        }
-      } finally {
-        setPreparingPaymentMethods((methods) => {
-          const nextMethods = new Set(methods)
-          nextMethods.delete(activePaymentMethod.id)
-          return nextMethods
-        })
-      }
+      return
     }
 
-    void prepare()
+    const transition = requestPaymentMethodPreparation(
+      paymentMethodPreparationState,
+      activePreparationKey
+    )
+    if (!transition.shouldPrepare) return
+
+    setPaymentMethodPreparationState(transition.state)
+    void paymentMethodPreparationRunner.run(activePreparationKey, () =>
+      runPaymentMethodPreparation(activePaymentMethod, activePreparationKey)
+    )
   }, [
+    activePaymentMethodIsPrepared,
+    activePreparationKey,
     activePaymentMethod,
-    appRun,
     isPaid,
     payment,
-    paymentId,
-    preparingPaymentMethods,
-    console,
+    paymentMethodPreparationRunner,
+    paymentMethodPreparationState,
+    runPaymentMethodPreparation,
   ])
+
+  const handleRetryPaymentMethodPreparation = () => {
+    if (
+      activePaymentMethod === null ||
+      activePreparationKey === null ||
+      activePaymentMethodIsPrepared ||
+      isPaid
+    ) {
+      return
+    }
+
+    const transition = retryPaymentMethodPreparation(
+      paymentMethodPreparationState,
+      activePreparationKey
+    )
+    if (!transition.shouldPrepare) return
+
+    setPaymentMethodPreparationState(transition.state)
+    void paymentMethodPreparationRunner.run(activePreparationKey, () =>
+      runPaymentMethodPreparation(activePaymentMethod, activePreparationKey)
+    )
+  }
 
   if (!payment) {
     return (
@@ -624,9 +657,20 @@ function PaymentWaitingRequest({
           </div>
 
           {activePreparePaymentErrorKey ? (
-            <p className="max-w-72 text-balance text-sm font-medium text-destructive">
-              {t(activePreparePaymentErrorKey)}
-            </p>
+            <div className="flex flex-col items-center gap-3">
+              <p className="max-w-72 text-balance text-sm font-medium text-destructive">
+                {t(activePreparePaymentErrorKey)}
+              </p>
+              <Button
+                type="button"
+                variant="outline"
+                disabled={activePreparationStatus?.status === "preparing"}
+                aria-label={t("paymentWait.prepareRetry")}
+                onClick={handleRetryPaymentMethodPreparation}
+              >
+                {t("paymentWait.prepareRetry")}
+              </Button>
+            </div>
           ) : null}
 
           {activePreparingPaymentMethodKey ? (


### PR DESCRIPTION
## Summary
- persist failed payment-method preparation state per payment/method/account key
- show an explicit localized retry action after a failed preparation
- deduplicate replayed effects and repeated retries while allowing a new attempt after settlement

## Verification
- `bunx vitest run src/features/payment-wait/payment-method-preparation.test.ts` - 5 passed
- `bun run check:lint` - passed
- `bun run check:ts` - passed
- `bun run build` - passed
- `bun run check:tests` - environment failure on Node 22: 114 existing tests require `Promise.try` / `AsyncDisposableStack`; focused tests pass

Closes #42