### PR TITLE
fix: attribute withdrawals to current device

### DIFF
--- a/src/core/modules/withdrawal/withdrawal-actions.test.ts
+++ b/src/core/modules/withdrawal/withdrawal-actions.test.ts
@@ -1,4 +1,4 @@
-import { testCreateRun } from "@evolu/common"
+import { createIdFromString, testCreateRun } from "@evolu/common"
 import { describe, expect, test } from "vitest"
 
 import type { DateDep } from "@/core/deps.ts"
@@ -56,6 +56,11 @@ const accountTransactionsWithOnchainQuery = (accountId: AccountId) =>
         "accountTransactionOnchain.id",
         "accountTransaction.id"
       )
+      .innerJoin(
+        "accountTransactionSource",
+        "accountTransactionSource.accountTransactionId",
+        "accountTransaction.id"
+      )
       .select([
         "accountTransaction.id",
         "accountTransaction.accountId",
@@ -67,6 +72,8 @@ const accountTransactionsWithOnchainQuery = (accountId: AccountId) =>
         "accountTransactionOnchain.exitSpeed",
         "accountTransactionOnchain.feeSats",
         "accountTransactionOnchain.txid",
+        "accountTransactionSource.deviceId",
+        "accountTransactionSource.source",
       ])
       .where("accountTransaction.accountId", "=", accountId)
   )
@@ -245,6 +252,7 @@ describe("executeWithdrawal", () => {
     } satisfies EvoluDep & DateDep & SparkWalletDep
     await using run = testCreateRun(deps)
     const exitSpeed: SparkExitSpeed = "medium"
+    const deviceId = createIdFromString<"Device">("withdrawal-test-device")
 
     const result = await run(
       executeWithdrawal({
@@ -255,6 +263,7 @@ describe("executeWithdrawal", () => {
         availableSats: 100_000,
         exitSpeed,
         feeQuote,
+        deviceId,
       })
     )
 
@@ -281,6 +290,8 @@ describe("executeWithdrawal", () => {
           exitSpeed: "medium",
           feeSats: 500,
           txid: "txid-1",
+          deviceId,
+          source: "manual",
         },
       ])
   })

--- a/src/features/withdraw/withdraw-page.tsx
+++ b/src/features/withdraw/withdraw-page.tsx
@@ -1,6 +1,7 @@
 import type { AbortError } from "@evolu/common"
 import { Link } from "@tanstack/react-router"
 import assertNever from "assert-never"
+import { useStore } from "jotai"
 import {
   ArrowLeftIcon,
   ClipboardPasteIcon,
@@ -12,6 +13,7 @@ import {
 import { type FormEvent, useEffect, useState } from "react"
 import { toast } from "sonner"
 
+import { accountAtom } from "@/atoms/account.ts"
 import { FadeHeader } from "@/components/fade-header.tsx"
 import { PaymentSuccess } from "@/components/payment-success.tsx"
 import { Button } from "@/components/ui/button.tsx"
@@ -114,6 +116,7 @@ const confirmErrorKey = (error: ConfirmWithdrawalError): TranslationKey => {
 
 export function WithdrawPage() {
   const appRun = useAppRun()
+  const jotaiStore = useStore()
   const { t } = useTranslation()
   const locale = useLocale()
   const { data: sparkAccountsData } = useEvoluQuery(activeSparkAccountsQuery)
@@ -256,6 +259,7 @@ export function WithdrawPage() {
     setConfirmPending(true)
     setConfirmError(null)
     try {
+      const { device } = await jotaiStore.get(accountAtom)
       await using run = appRun()
       const executeResult = await run(
         executeWithdrawal({
@@ -266,6 +270,7 @@ export function WithdrawPage() {
           availableSats: quote.availableSats,
           exitSpeed,
           feeQuote: quote.feeQuote,
+          deviceId: device.id,
         })
       )
 


### PR DESCRIPTION
## Summary
- resolve the current device only when withdrawal confirmation executes
- pass that device ID to `executeWithdrawal` for manual source attribution
- cover persisted manual withdrawal source attribution in the focused action test

## Verification
- `npx --yes node@24 node_modules/vitest/vitest.mjs run src/core/modules/withdrawal/withdrawal-actions.test.ts` (9/9 passed)
- `PATH=<Node 24 bin>:$PATH npx --yes bun run check` (32 files, 182 tests passed)
- `PATH=<Node 24 bin>:$PATH npx --yes bun run build` (passed; existing chunk-size warning only)
- `git diff --check origin/main...HEAD` (passed)

Closes #52