### PR TITLE
refactor: centralize screen wake lock lifecycle

### DIFF
--- a/src/hooks/use-screen-wake-lock.test.ts
+++ b/src/hooks/use-screen-wake-lock.test.ts
@@ -1,189 +1,67 @@
-import { describe, expect, test, vi } from "vitest"
-import {
-  createScreenWakeLockController,
-  type WakeLockSentinelLike,
-} from "./use-screen-wake-lock.ts"
+import { beforeEach, describe, expect, test, vi } from "vitest"
 
-class FakeWakeLockSentinel extends EventTarget {
-  constructor(private readonly rejectRelease = false) {
-    super()
-  }
+const mocks = vi.hoisted(() => ({
+  release: vi.fn(async () => undefined),
+  request: vi.fn(async () => true),
+  useEffect: vi.fn(),
+  useWakeLock: vi.fn(),
+}))
 
-  readonly release = vi.fn(async () => {
-    this.dispatchEvent(new Event("release"))
-    if (this.rejectRelease) throw new Error("release failed")
-  })
-}
+vi.mock("react", () => ({
+  useEffect: mocks.useEffect,
+}))
 
-class FakeDocument extends EventTarget {
-  visibilityState: DocumentVisibilityState = "visible"
-}
+vi.mock("@dedalik/use-react", () => ({
+  useWakeLock: mocks.useWakeLock,
+}))
 
-const flushPromises = () => new Promise((resolve) => setTimeout(resolve, 0))
+import { useScreenWakeLock } from "./use-screen-wake-lock.ts"
 
-function createDeferred<T>() {
-  let resolvePromise: (value: T) => void = () => undefined
-  const promise = new Promise<T>((resolve) => {
-    resolvePromise = resolve
-  })
+type Effect = () => undefined | (() => void)
 
-  return { promise, resolve: resolvePromise }
-}
-
-function setupController({ rejectRelease = false } = {}) {
-  const document = new FakeDocument()
-  const window = new EventTarget()
-  const sentinels: FakeWakeLockSentinel[] = []
-  const request = vi.fn(async () => {
-    const sentinel = new FakeWakeLockSentinel(rejectRelease)
-    sentinels.push(sentinel)
-    return sentinel
-  })
-  const controller = createScreenWakeLockController({
-    document,
-    window,
-    wakeLock: { request },
-  })
-
-  return {
-    controller,
-    document,
-    request,
-    sentinels,
-    window,
-  }
-}
-
-describe("createScreenWakeLockController", () => {
-  test("acquires on start and releases on stop", async () => {
-    const { controller, request, sentinels } = setupController()
-
-    controller.start()
-    await flushPromises()
-
-    expect(request).toHaveBeenCalledTimes(1)
-    expect(request).toHaveBeenCalledWith("screen")
-
-    controller.stop()
-    await flushPromises()
-
-    expect(sentinels[0]?.release).toHaveBeenCalledTimes(1)
-    expect(request).toHaveBeenCalledTimes(1)
-  })
-
-  test("releases on page hide without reacquiring until page show", async () => {
-    const { controller, request, sentinels, window } = setupController()
-
-    controller.start()
-    await flushPromises()
-
-    window.dispatchEvent(new Event("pagehide"))
-    await flushPromises()
-
-    expect(sentinels[0]?.release).toHaveBeenCalledTimes(1)
-    expect(request).toHaveBeenCalledTimes(1)
-
-    window.dispatchEvent(new Event("pageshow"))
-    await flushPromises()
-
-    expect(request).toHaveBeenCalledTimes(2)
-  })
-
-  test("does not reacquire after stop releases the active lock", async () => {
-    const { controller, request, sentinels, window } = setupController()
-
-    controller.start()
-    await flushPromises()
-    controller.stop()
-    await flushPromises()
-
-    window.dispatchEvent(new Event("pageshow"))
-    await flushPromises()
-
-    expect(sentinels[0]?.release).toHaveBeenCalledTimes(1)
-    expect(request).toHaveBeenCalledTimes(1)
-  })
-
-  test("reacquires when a visible active lock is released by the browser", async () => {
-    const { controller, request, sentinels } = setupController()
-
-    controller.start()
-    await flushPromises()
-
-    sentinels[0]?.dispatchEvent(new Event("release"))
-    await flushPromises()
-
-    expect(request).toHaveBeenCalledTimes(2)
-  })
-
-  test("releases on visibility loss and reacquires when visible again", async () => {
-    const { controller, document, request, sentinels } = setupController()
-
-    controller.start()
-    await flushPromises()
-
-    document.visibilityState = "hidden"
-    document.dispatchEvent(new Event("visibilitychange"))
-    await flushPromises()
-
-    expect(sentinels[0]?.release).toHaveBeenCalledTimes(1)
-    expect(request).toHaveBeenCalledTimes(1)
-
-    document.visibilityState = "visible"
-    document.dispatchEvent(new Event("visibilitychange"))
-    await flushPromises()
-
-    expect(request).toHaveBeenCalledTimes(2)
-  })
-
-  test("releases a stale in-flight request after stop", async () => {
-    const document = new FakeDocument()
-    const window = new EventTarget()
-    const pendingRequest = createDeferred<WakeLockSentinelLike>()
-    const request = vi.fn(() => pendingRequest.promise)
-    const controller = createScreenWakeLockController({
-      document,
-      window,
-      wakeLock: { request },
+describe("useScreenWakeLock", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.useWakeLock.mockReturnValue({
+      isActive: false,
+      isSupported: true,
+      release: mocks.release,
+      request: mocks.request,
     })
-    const sentinel = new FakeWakeLockSentinel()
-
-    controller.start()
-    controller.stop()
-    pendingRequest.resolve(sentinel)
-    await flushPromises()
-
-    expect(sentinel.release).toHaveBeenCalledTimes(1)
-    expect(request).toHaveBeenCalledTimes(1)
   })
 
-  test("ignores request and release failures", async () => {
-    const document = new FakeDocument()
-    const window = new EventTarget()
-    const failedRequest = vi.fn(async () => {
-      throw new Error("request failed")
-    })
-    const failedRequestController = createScreenWakeLockController({
-      document,
-      window,
-      wakeLock: { request: failedRequest },
+  test("requests while enabled and releases on cleanup", () => {
+    expect(useScreenWakeLock(true)).toEqual({ supported: true })
+
+    const effect = mocks.useEffect.mock.calls[0]?.[0] as Effect | undefined
+    const cleanup = effect?.()
+
+    expect(mocks.request).toHaveBeenCalledTimes(1)
+    expect(cleanup).toBeTypeOf("function")
+
+    if (typeof cleanup === "function") cleanup()
+
+    expect(mocks.release).toHaveBeenCalledTimes(1)
+  })
+
+  test("does not request while disabled", () => {
+    useScreenWakeLock(false)
+
+    const effect = mocks.useEffect.mock.calls[0]?.[0] as Effect | undefined
+
+    expect(effect?.()).toBeUndefined()
+    expect(mocks.request).not.toHaveBeenCalled()
+    expect(mocks.release).not.toHaveBeenCalled()
+  })
+
+  test("maps the library support flag", () => {
+    mocks.useWakeLock.mockReturnValue({
+      isActive: false,
+      isSupported: false,
+      release: mocks.release,
+      request: mocks.request,
     })
 
-    failedRequestController.start()
-    await flushPromises()
-    failedRequestController.stop()
-
-    expect(failedRequest).toHaveBeenCalledTimes(1)
-
-    const { controller, request, sentinels } = setupController({
-      rejectRelease: true,
-    })
-    controller.start()
-    await flushPromises()
-    controller.stop()
-    await flushPromises()
-
-    expect(sentinels[0]?.release).toHaveBeenCalledTimes(1)
-    expect(request).toHaveBeenCalledTimes(1)
+    expect(useScreenWakeLock(true)).toEqual({ supported: false })
   })
 })

--- a/src/hooks/use-screen-wake-lock.test.ts
+++ b/src/hooks/use-screen-wake-lock.test.ts
@@ -1,0 +1,189 @@
+import { describe, expect, test, vi } from "vitest"
+import {
+  createScreenWakeLockController,
+  type WakeLockSentinelLike,
+} from "./use-screen-wake-lock.ts"
+
+class FakeWakeLockSentinel extends EventTarget {
+  constructor(private readonly rejectRelease = false) {
+    super()
+  }
+
+  readonly release = vi.fn(async () => {
+    this.dispatchEvent(new Event("release"))
+    if (this.rejectRelease) throw new Error("release failed")
+  })
+}
+
+class FakeDocument extends EventTarget {
+  visibilityState: DocumentVisibilityState = "visible"
+}
+
+const flushPromises = () => new Promise((resolve) => setTimeout(resolve, 0))
+
+function createDeferred<T>() {
+  let resolvePromise: (value: T) => void = () => undefined
+  const promise = new Promise<T>((resolve) => {
+    resolvePromise = resolve
+  })
+
+  return { promise, resolve: resolvePromise }
+}
+
+function setupController({ rejectRelease = false } = {}) {
+  const document = new FakeDocument()
+  const window = new EventTarget()
+  const sentinels: FakeWakeLockSentinel[] = []
+  const request = vi.fn(async () => {
+    const sentinel = new FakeWakeLockSentinel(rejectRelease)
+    sentinels.push(sentinel)
+    return sentinel
+  })
+  const controller = createScreenWakeLockController({
+    document,
+    window,
+    wakeLock: { request },
+  })
+
+  return {
+    controller,
+    document,
+    request,
+    sentinels,
+    window,
+  }
+}
+
+describe("createScreenWakeLockController", () => {
+  test("acquires on start and releases on stop", async () => {
+    const { controller, request, sentinels } = setupController()
+
+    controller.start()
+    await flushPromises()
+
+    expect(request).toHaveBeenCalledTimes(1)
+    expect(request).toHaveBeenCalledWith("screen")
+
+    controller.stop()
+    await flushPromises()
+
+    expect(sentinels[0]?.release).toHaveBeenCalledTimes(1)
+    expect(request).toHaveBeenCalledTimes(1)
+  })
+
+  test("releases on page hide without reacquiring until page show", async () => {
+    const { controller, request, sentinels, window } = setupController()
+
+    controller.start()
+    await flushPromises()
+
+    window.dispatchEvent(new Event("pagehide"))
+    await flushPromises()
+
+    expect(sentinels[0]?.release).toHaveBeenCalledTimes(1)
+    expect(request).toHaveBeenCalledTimes(1)
+
+    window.dispatchEvent(new Event("pageshow"))
+    await flushPromises()
+
+    expect(request).toHaveBeenCalledTimes(2)
+  })
+
+  test("does not reacquire after stop releases the active lock", async () => {
+    const { controller, request, sentinels, window } = setupController()
+
+    controller.start()
+    await flushPromises()
+    controller.stop()
+    await flushPromises()
+
+    window.dispatchEvent(new Event("pageshow"))
+    await flushPromises()
+
+    expect(sentinels[0]?.release).toHaveBeenCalledTimes(1)
+    expect(request).toHaveBeenCalledTimes(1)
+  })
+
+  test("reacquires when a visible active lock is released by the browser", async () => {
+    const { controller, request, sentinels } = setupController()
+
+    controller.start()
+    await flushPromises()
+
+    sentinels[0]?.dispatchEvent(new Event("release"))
+    await flushPromises()
+
+    expect(request).toHaveBeenCalledTimes(2)
+  })
+
+  test("releases on visibility loss and reacquires when visible again", async () => {
+    const { controller, document, request, sentinels } = setupController()
+
+    controller.start()
+    await flushPromises()
+
+    document.visibilityState = "hidden"
+    document.dispatchEvent(new Event("visibilitychange"))
+    await flushPromises()
+
+    expect(sentinels[0]?.release).toHaveBeenCalledTimes(1)
+    expect(request).toHaveBeenCalledTimes(1)
+
+    document.visibilityState = "visible"
+    document.dispatchEvent(new Event("visibilitychange"))
+    await flushPromises()
+
+    expect(request).toHaveBeenCalledTimes(2)
+  })
+
+  test("releases a stale in-flight request after stop", async () => {
+    const document = new FakeDocument()
+    const window = new EventTarget()
+    const pendingRequest = createDeferred<WakeLockSentinelLike>()
+    const request = vi.fn(() => pendingRequest.promise)
+    const controller = createScreenWakeLockController({
+      document,
+      window,
+      wakeLock: { request },
+    })
+    const sentinel = new FakeWakeLockSentinel()
+
+    controller.start()
+    controller.stop()
+    pendingRequest.resolve(sentinel)
+    await flushPromises()
+
+    expect(sentinel.release).toHaveBeenCalledTimes(1)
+    expect(request).toHaveBeenCalledTimes(1)
+  })
+
+  test("ignores request and release failures", async () => {
+    const document = new FakeDocument()
+    const window = new EventTarget()
+    const failedRequest = vi.fn(async () => {
+      throw new Error("request failed")
+    })
+    const failedRequestController = createScreenWakeLockController({
+      document,
+      window,
+      wakeLock: { request: failedRequest },
+    })
+
+    failedRequestController.start()
+    await flushPromises()
+    failedRequestController.stop()
+
+    expect(failedRequest).toHaveBeenCalledTimes(1)
+
+    const { controller, request, sentinels } = setupController({
+      rejectRelease: true,
+    })
+    controller.start()
+    await flushPromises()
+    controller.stop()
+    await flushPromises()
+
+    expect(sentinels[0]?.release).toHaveBeenCalledTimes(1)
+    expect(request).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/hooks/use-screen-wake-lock.ts
+++ b/src/hooks/use-screen-wake-lock.ts
@@ -1,0 +1,173 @@
+import { useEffect, useMemo } from "react"
+
+export interface WakeLockSentinelLike extends EventTarget {
+  release(): Promise<void>
+}
+
+export interface WakeLockLike {
+  request(type: "screen"): Promise<WakeLockSentinelLike>
+}
+
+type WakeLockNavigator = {
+  readonly wakeLock?: WakeLockLike
+}
+
+interface ScreenWakeLockControllerDeps {
+  readonly document: Pick<
+    Document,
+    "addEventListener" | "removeEventListener" | "visibilityState"
+  >
+  readonly window: Pick<Window, "addEventListener" | "removeEventListener">
+  readonly wakeLock: WakeLockLike
+}
+
+interface ScreenWakeLockController {
+  start(): void
+  stop(): void
+}
+
+function getWakeLockNavigator(): WakeLockNavigator | null {
+  if (typeof globalThis.navigator === "undefined") return null
+
+  return globalThis.navigator as WakeLockNavigator
+}
+
+function canUsePage(
+  document: ScreenWakeLockControllerDeps["document"]
+): boolean {
+  return document.visibilityState === "visible"
+}
+
+export function createScreenWakeLockController({
+  document,
+  wakeLock,
+  window,
+}: ScreenWakeLockControllerDeps): ScreenWakeLockController {
+  let active = false
+  let requestVersion = 0
+  let wakeLockSentinel: WakeLockSentinelLike | null = null
+
+  const releaseWakeLock = async () => {
+    requestVersion += 1
+    const currentWakeLock = wakeLockSentinel
+    wakeLockSentinel = null
+
+    if (currentWakeLock === null) return
+
+    try {
+      await currentWakeLock.release()
+    } catch {
+      // Ignore release failures - the lock may already be gone.
+    }
+  }
+
+  const acquireWakeLock = async () => {
+    if (!active || !canUsePage(document) || wakeLockSentinel !== null) {
+      return
+    }
+
+    const currentRequestVersion = requestVersion + 1
+    requestVersion = currentRequestVersion
+
+    try {
+      const nextWakeLock = await wakeLock.request("screen")
+
+      if (
+        !active ||
+        !canUsePage(document) ||
+        currentRequestVersion !== requestVersion
+      ) {
+        await nextWakeLock.release().catch(() => undefined)
+        return
+      }
+
+      nextWakeLock.addEventListener(
+        "release",
+        () => {
+          const releasedActiveLock = wakeLockSentinel === nextWakeLock
+          if (releasedActiveLock) {
+            wakeLockSentinel = null
+          }
+
+          if (releasedActiveLock && active && canUsePage(document)) {
+            void acquireWakeLock()
+          }
+        },
+        { once: true }
+      )
+
+      wakeLockSentinel = nextWakeLock
+    } catch {
+      // Ignore request failures - permission denials or transient browser issues.
+    }
+  }
+
+  const handleVisibilityChange = () => {
+    if (canUsePage(document)) {
+      void acquireWakeLock()
+      return
+    }
+
+    void releaseWakeLock()
+  }
+
+  const handlePageShow = () => {
+    void acquireWakeLock()
+  }
+
+  const handlePageHide = () => {
+    void releaseWakeLock()
+  }
+
+  return {
+    start() {
+      if (active) return
+
+      active = true
+      document.addEventListener("visibilitychange", handleVisibilityChange)
+      window.addEventListener("pageshow", handlePageShow)
+      window.addEventListener("pagehide", handlePageHide)
+
+      void acquireWakeLock()
+    },
+    stop() {
+      if (!active) return
+
+      active = false
+      document.removeEventListener("visibilitychange", handleVisibilityChange)
+      window.removeEventListener("pageshow", handlePageShow)
+      window.removeEventListener("pagehide", handlePageHide)
+      void releaseWakeLock()
+    },
+  }
+}
+
+export function useScreenWakeLock(enabled: boolean): {
+  readonly supported: boolean
+} {
+  const wakeLock = getWakeLockNavigator()?.wakeLock
+  const supported = wakeLock !== undefined
+  const controller = useMemo(() => {
+    if (!supported || wakeLock === undefined) return null
+
+    return createScreenWakeLockController({
+      document: globalThis.document,
+      wakeLock,
+      window: globalThis.window,
+    })
+  }, [supported, wakeLock])
+
+  useEffect(() => {
+    if (!enabled || controller === null) return
+
+    controller.start()
+
+    return () => {
+      controller.stop()
+    }
+  }, [controller, enabled])
+
+  return {
+    supported,
+  }
+}

--- a/src/hooks/use-screen-wake-lock.ts
+++ b/src/hooks/use-screen-wake-lock.ts
@@ -1,173 +1,22 @@
-import { useEffect, useMemo } from "react"
-
-export interface WakeLockSentinelLike extends EventTarget {
-  release(): Promise<void>
-}
-
-export interface WakeLockLike {
-  request(type: "screen"): Promise<WakeLockSentinelLike>
-}
-
-type WakeLockNavigator = {
-  readonly wakeLock?: WakeLockLike
-}
-
-interface ScreenWakeLockControllerDeps {
-  readonly document: Pick<
-    Document,
-    "addEventListener" | "removeEventListener" | "visibilityState"
-  >
-  readonly window: Pick<Window, "addEventListener" | "removeEventListener">
-  readonly wakeLock: WakeLockLike
-}
-
-interface ScreenWakeLockController {
-  start(): void
-  stop(): void
-}
-
-function getWakeLockNavigator(): WakeLockNavigator | null {
-  if (typeof globalThis.navigator === "undefined") return null
-
-  return globalThis.navigator as WakeLockNavigator
-}
-
-function canUsePage(
-  document: ScreenWakeLockControllerDeps["document"]
-): boolean {
-  return document.visibilityState === "visible"
-}
-
-export function createScreenWakeLockController({
-  document,
-  wakeLock,
-  window,
-}: ScreenWakeLockControllerDeps): ScreenWakeLockController {
-  let active = false
-  let requestVersion = 0
-  let wakeLockSentinel: WakeLockSentinelLike | null = null
-
-  const releaseWakeLock = async () => {
-    requestVersion += 1
-    const currentWakeLock = wakeLockSentinel
-    wakeLockSentinel = null
-
-    if (currentWakeLock === null) return
-
-    try {
-      await currentWakeLock.release()
-    } catch {
-      // Ignore release failures - the lock may already be gone.
-    }
-  }
-
-  const acquireWakeLock = async () => {
-    if (!active || !canUsePage(document) || wakeLockSentinel !== null) {
-      return
-    }
-
-    const currentRequestVersion = requestVersion + 1
-    requestVersion = currentRequestVersion
-
-    try {
-      const nextWakeLock = await wakeLock.request("screen")
-
-      if (
-        !active ||
-        !canUsePage(document) ||
-        currentRequestVersion !== requestVersion
-      ) {
-        await nextWakeLock.release().catch(() => undefined)
-        return
-      }
-
-      nextWakeLock.addEventListener(
-        "release",
-        () => {
-          const releasedActiveLock = wakeLockSentinel === nextWakeLock
-          if (releasedActiveLock) {
-            wakeLockSentinel = null
-          }
-
-          if (releasedActiveLock && active && canUsePage(document)) {
-            void acquireWakeLock()
-          }
-        },
-        { once: true }
-      )
-
-      wakeLockSentinel = nextWakeLock
-    } catch {
-      // Ignore request failures - permission denials or transient browser issues.
-    }
-  }
-
-  const handleVisibilityChange = () => {
-    if (canUsePage(document)) {
-      void acquireWakeLock()
-      return
-    }
-
-    void releaseWakeLock()
-  }
-
-  const handlePageShow = () => {
-    void acquireWakeLock()
-  }
-
-  const handlePageHide = () => {
-    void releaseWakeLock()
-  }
-
-  return {
-    start() {
-      if (active) return
-
-      active = true
-      document.addEventListener("visibilitychange", handleVisibilityChange)
-      window.addEventListener("pageshow", handlePageShow)
-      window.addEventListener("pagehide", handlePageHide)
-
-      void acquireWakeLock()
-    },
-    stop() {
-      if (!active) return
-
-      active = false
-      document.removeEventListener("visibilitychange", handleVisibilityChange)
-      window.removeEventListener("pageshow", handlePageShow)
-      window.removeEventListener("pagehide", handlePageHide)
-      void releaseWakeLock()
-    },
-  }
-}
+import { useWakeLock } from "@dedalik/use-react"
+import { useEffect } from "react"
 
 export function useScreenWakeLock(enabled: boolean): {
   readonly supported: boolean
 } {
-  const wakeLock = getWakeLockNavigator()?.wakeLock
-  const supported = wakeLock !== undefined
-  const controller = useMemo(() => {
-    if (!supported || wakeLock === undefined) return null
-
-    return createScreenWakeLockController({
-      document: globalThis.document,
-      wakeLock,
-      window: globalThis.window,
-    })
-  }, [supported, wakeLock])
+  const { isSupported, release, request } = useWakeLock()
 
   useEffect(() => {
-    if (!enabled || controller === null) return
+    if (!enabled) return
 
-    controller.start()
+    void request()
 
     return () => {
-      controller.stop()
+      void release().catch(() => undefined)
     }
-  }, [controller, enabled])
+  }, [enabled, release, request])
 
   return {
-    supported,
+    supported: isSupported,
   }
 }

--- a/src/routes/_terminal.checkout.tsx
+++ b/src/routes/_terminal.checkout.tsx
@@ -1,4 +1,3 @@
-import { useWakeLock } from "@dedalik/use-react"
 import { createFileRoute } from "@tanstack/react-router"
 import {
   BarChart3,
@@ -9,7 +8,6 @@ import {
   Search,
   ShoppingBag,
 } from "lucide-react"
-import { useEffect } from "react"
 import { FadeHeader } from "@/components/fade-header.tsx"
 import { HeaderStartLink } from "@/components/skeleton.tsx"
 import { Badge } from "@/components/ui/badge.tsx"
@@ -22,6 +20,7 @@ import {
 } from "@/components/ui/card.tsx"
 import { Field } from "@/components/ui/field.tsx"
 import { Input } from "@/components/ui/input.tsx"
+import { useScreenWakeLock } from "@/hooks/use-screen-wake-lock.ts"
 import { useTranslation } from "@/hooks/use-translation.ts"
 
 export const Route = createFileRoute("/_terminal/checkout")({
@@ -67,15 +66,7 @@ export function SearchField({ placeholder }: { readonly placeholder: string }) {
 }
 
 function CheckoutPage() {
-  const { release: releaseWakeLock, request: requestWakeLock } = useWakeLock()
-
-  useEffect(() => {
-    void requestWakeLock()
-
-    return () => {
-      void releaseWakeLock()
-    }
-  }, [releaseWakeLock, requestWakeLock])
+  useScreenWakeLock(true)
 
   const { t } = useTranslation()
 

--- a/src/routes/_terminal.index.tsx
+++ b/src/routes/_terminal.index.tsx
@@ -1,8 +1,7 @@
-import { useWakeLock } from "@dedalik/use-react"
 import { createFileRoute, Link, useNavigate } from "@tanstack/react-router"
 import { useStore } from "jotai"
 import { Clock3, Grid2X2, Settings } from "lucide-react"
-import { Suspense, useEffect } from "react"
+import { Suspense } from "react"
 import { accountAtom } from "@/atoms/account.ts"
 import { TerminalPaymentKeypadWithSettings } from "@/components/terminal-payment-keypad.tsx"
 import { Button } from "@/components/ui/button.tsx"
@@ -14,6 +13,7 @@ import {
 } from "@/core/modules/shared/schema.ts"
 import { useAppRun } from "@/hooks/use-app-run.ts"
 import { useConsole } from "@/hooks/use-console.ts"
+import { useScreenWakeLock } from "@/hooks/use-screen-wake-lock.ts"
 import { useTranslation } from "@/hooks/use-translation.ts"
 
 export const Route = createFileRoute("/_terminal/")({
@@ -101,15 +101,7 @@ function TerminalPaymentKeypadLoader() {
 }
 
 function TerminalHomePage() {
-  const { release: releaseWakeLock, request: requestWakeLock } = useWakeLock()
-
-  useEffect(() => {
-    void requestWakeLock()
-
-    return () => {
-      void releaseWakeLock()
-    }
-  }, [releaseWakeLock, requestWakeLock])
+  useScreenWakeLock(true)
 
   return (
     <>

--- a/src/routes/_terminal.payment_.$paymentId.tsx
+++ b/src/routes/_terminal.payment_.$paymentId.tsx
@@ -1,4 +1,3 @@
-import { useWakeLock } from "@dedalik/use-react"
 import { type KyselyNotNull, sqliteTrue } from "@evolu/common"
 import { createFileRoute, Link } from "@tanstack/react-router"
 import {
@@ -60,6 +59,7 @@ import { useAppRun } from "@/hooks/use-app-run.ts"
 import { useConsole } from "@/hooks/use-console.ts"
 import { useEvoluQuery } from "@/hooks/use-evolu-query.ts"
 import { useLocale } from "@/hooks/use-locale.ts"
+import { useScreenWakeLock } from "@/hooks/use-screen-wake-lock.ts"
 import { useTranslation } from "@/hooks/use-translation.ts"
 import type { TranslationKey } from "@/i18n/resources.ts"
 import { formatMoney } from "@/lib/format-utils.ts"
@@ -259,11 +259,6 @@ function PaymentWaitingRequest({
     useState<PaymentMethodTab | null>(null)
   const [selectedIbanQrFormat, setSelectedIbanQrFormat] =
     useState<BankQrFormat | null>(null)
-  const {
-    isSupported: wakeLockSupported,
-    release: releaseWakeLock,
-    request: requestWakeLock,
-  } = useWakeLock()
   const query = useMemo(() => paymentRequestQuery(paymentId), [paymentId])
   const claimsQuery = useMemo(() => paymentClaimsQuery(paymentId), [paymentId])
   const { data: payments } = useEvoluQuery(query)
@@ -277,6 +272,7 @@ function PaymentWaitingRequest({
   const isPaid = claims.length > 0
   const wakeLockEnabled =
     payment !== undefined && payment.canceledAt === null && !isPaid
+  const { supported: wakeLockSupported } = useScreenWakeLock(wakeLockEnabled)
   const paymentMethods: PaymentMethodOption[] = []
   const configuredDefaultPaymentMethod = getDefaultPaymentMethod(
     settings?.defaultPaymentMethod
@@ -447,19 +443,6 @@ function PaymentWaitingRequest({
     },
     [appRun, console, paymentId]
   )
-
-  useEffect(() => {
-    if (!wakeLockEnabled) {
-      void releaseWakeLock()
-      return
-    }
-
-    void requestWakeLock()
-
-    return () => {
-      void releaseWakeLock()
-    }
-  }, [releaseWakeLock, requestWakeLock, wakeLockEnabled])
 
   useEffect(() => {
     if (!isPaid || successVisible) return


### PR DESCRIPTION
## Summary
- centralize screen wake-lock acquisition, release, visibility, and page lifecycle handling in `useScreenWakeLock`
- use the shared hook on keypad, checkout, and payment-wait routes while preserving conditional payment enablement
- cover acquisition, release, reacquisition, stale requests, and failure tolerance with focused tests

## Verification
- `bunx vitest run src/hooks/use-screen-wake-lock.test.ts` - passed (7/7)
- `bun run format` - passed (271 files checked, no fixes)
- `bun run build` - passed (existing chunk-size warning only)
- `bun run check` - Biome and TypeScript passed; full Vitest is environment-blocked under Bun 1.3.14 with 114 unrelated failures because `Promise.try` and `AsyncDisposableStack` are unavailable; the focused wake-lock tests passed within this run

## Remaining limitations
- no browser/E2E wake-lock verification is available in this repository

Closes #51