### PR TITLE
feat(onboarding): add account restore flow

### DIFF
--- a/src/core/evolu/device-account.ts
+++ b/src/core/evolu/device-account.ts
@@ -134,6 +134,8 @@ export const createAccountMnemonic = (): Mnemonic =>
 export const createRandomAccountName = () =>
   NonEmptyString255(faker.internet.username())
 
+const defaultEvoluTransportUrl = WssUrl("wss://free.evoluhq.com")
+
 const createAccountEvoluTransportId = ({
   accountId,
   type,
@@ -196,8 +198,6 @@ export const insertAccount = (
   const name = accountName
     ? NonEmptyString255(accountName)
     : createRandomAccountName()
-  const transportUrl = WssUrl("wss://free.evoluhq.com")
-
   const { id: accountId } = deviceEvolu.insert("account", {
     name,
     mnemonic,
@@ -206,7 +206,7 @@ export const insertAccount = (
   upsertAccountEvoluWebsocketTransport(deviceEvolu, {
     accountId,
     isActive: sqliteFalse,
-    url: transportUrl,
+    url: defaultEvoluTransportUrl,
   })
 
   return {
@@ -239,6 +239,27 @@ export async function createOrSelectAccount(
 
   const account = insertAccount(deviceEvolu, mnemonic)
   return { accountId: account.id, created: true }
+}
+
+/**
+ * Selects an account from a recovery phrase. Newly imported accounts activate
+ * the default relay so their remote application data can synchronize.
+ */
+export async function restoreOrSelectAccount(
+  deviceEvolu: DeviceEvolu,
+  mnemonic: Mnemonic
+): Promise<{ readonly accountId: AccountId; readonly created: boolean }> {
+  const result = await createOrSelectAccount(deviceEvolu, mnemonic)
+
+  if (result.created) {
+    upsertAccountEvoluWebsocketTransport(deviceEvolu, {
+      accountId: result.accountId,
+      isActive: sqliteTrue,
+      url: defaultEvoluTransportUrl,
+    })
+  }
+
+  return result
 }
 
 export function selectAccount(deviceEvolu: DeviceEvolu, accountId: AccountId) {

--- a/src/features/account/use-restore-account.ts
+++ b/src/features/account/use-restore-account.ts
@@ -1,0 +1,71 @@
+import { Mnemonic } from "@evolu/common"
+import { useAtomValue, useSetAtom } from "jotai"
+import { useState } from "react"
+
+import { deviceEvoluAtom } from "@/atoms/device-evolu.ts"
+import { evoluCounterAtom } from "@/atoms/evolu-counter.ts"
+import { restoreOrSelectAccount } from "@/core/evolu/device-account.ts"
+import { normalizeMnemonic } from "@/core/modules/account/account-utils.ts"
+import { useSettingsForm } from "@/features/settings/use-settings-form.ts"
+import type { TranslationKey } from "@/i18n/resources.ts"
+
+export interface RestoreAccount {
+  readonly mnemonic: string
+  readonly pending: boolean
+  readonly error: TranslationKey | null
+  readonly clearError: () => void
+  readonly setMnemonic: (mnemonic: string) => void
+  readonly restore: () => Promise<boolean>
+}
+
+/**
+ * Validates a recovery phrase, selects its device account, and recreates the
+ * app Evolu client for the selected account.
+ */
+export function useRestoreAccount(): RestoreAccount {
+  const deviceEvolu = useAtomValue(deviceEvoluAtom)
+  const setEvoluCounter = useSetAtom(evoluCounterAtom)
+  const [mnemonic, setMnemonicValue] = useState("")
+  const { pending, error, setError, submit } = useSettingsForm()
+
+  const setMnemonic = (nextMnemonic: string) => {
+    setMnemonicValue(nextMnemonic)
+    setError(null)
+  }
+
+  const restore = async (): Promise<boolean> => {
+    setError(null)
+
+    const normalizedMnemonic = normalizeMnemonic(mnemonic)
+
+    if (normalizedMnemonic === "") {
+      setError("settings.accounts.restore.mnemonic.required")
+      return false
+    }
+
+    const mnemonicResult = Mnemonic.from(normalizedMnemonic)
+
+    if (!mnemonicResult.ok) {
+      setError("settings.accounts.restore.mnemonic.invalid")
+      return false
+    }
+
+    await submit(async () => {
+      await restoreOrSelectAccount(deviceEvolu, mnemonicResult.value)
+      setEvoluCounter((current) => current + 1)
+    })
+
+    return true
+  }
+
+  return {
+    mnemonic,
+    pending,
+    error,
+    clearError: () => {
+      setError(null)
+    },
+    setMnemonic,
+    restore,
+  }
+}

--- a/src/features/onboarding/onboarding-form-state.test.ts
+++ b/src/features/onboarding/onboarding-form-state.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, test } from "vitest"
+
+import { getOnboardingSteps } from "@/features/onboarding/onboarding-form-state.ts"
+
+describe("getOnboardingSteps", () => {
+  test("includes the setup steps for a new account", () => {
+    expect(getOnboardingSteps("new")).toEqual([
+      "language",
+      "accountChoice",
+      "currency",
+      "payments",
+      "account",
+    ])
+  })
+
+  test("goes directly from account choice to recovery for restoration", () => {
+    expect(getOnboardingSteps("restore")).toEqual([
+      "language",
+      "accountChoice",
+      "restore",
+    ])
+  })
+})

--- a/src/features/onboarding/onboarding-form-state.ts
+++ b/src/features/onboarding/onboarding-form-state.ts
@@ -2,18 +2,40 @@ import { atom } from "jotai"
 
 import type { FiatCurrency } from "@/core/modules/shared/schema.ts"
 
-export type OnboardingStep = "language" | "currency" | "payments" | "account"
+export type OnboardingStep =
+  | "language"
+  | "accountChoice"
+  | "currency"
+  | "payments"
+  | "account"
+  | "restore"
+export type OnboardingAccountType = "new" | "restore"
 export type OnboardingPaymentMethod = "cash" | "btc" | "iban"
 
-export const onboardingSteps: ReadonlyArray<OnboardingStep> = [
+const newAccountOnboardingSteps: ReadonlyArray<OnboardingStep> = [
   "language",
+  "accountChoice",
   "currency",
   "payments",
   "account",
 ]
 
+const restoreAccountOnboardingSteps: ReadonlyArray<OnboardingStep> = [
+  "language",
+  "accountChoice",
+  "restore",
+]
+
+export const getOnboardingSteps = (
+  accountType: OnboardingAccountType | null
+): ReadonlyArray<OnboardingStep> =>
+  accountType === "restore"
+    ? restoreAccountOnboardingSteps
+    : newAccountOnboardingSteps
+
 export interface OnboardingFormState {
   readonly step: OnboardingStep
+  readonly accountType: OnboardingAccountType | null
   /** `null` until the user picks one; the UI derives a default from the language. */
   readonly currency: FiatCurrency | null
   readonly paymentMethods: ReadonlySet<OnboardingPaymentMethod>
@@ -22,6 +44,7 @@ export interface OnboardingFormState {
 
 export const initialOnboardingFormState: OnboardingFormState = {
   step: "language",
+  accountType: null,
   currency: null,
   paymentMethods: new Set(["cash", "btc"]),
   iban: "",

--- a/src/i18n/cs.ts
+++ b/src/i18n/cs.ts
@@ -3,6 +3,11 @@ import type { TranslationKey } from "@/i18n/en.ts"
 export const cs = {
   "accountRestore.description":
     "Čekáme na synchronizaci dat účtu. Obvykle to trvá pár sekund.",
+  "accountRestore.timeout.continue": "Čekat dál",
+  "accountRestore.timeout.description":
+    "Nastavení účtu zatím nedorazilo. Můžete dále čekat nebo tento účet výslovně nastavit jako nový.",
+  "accountRestore.timeout.setup": "Nastavit jako nový účet",
+  "accountRestore.timeout.title": "Obnova účtu stále probíhá",
   "accountRestore.title": "Obnovování účtu",
   "activity.amount.btc": "฿145",
   "activity.amount.usd": "$9.00",
@@ -206,6 +211,15 @@ export const cs = {
   "nav.settings": "Nastavení",
   "onboarding.account.description":
     "Zkontrolujte identitu, kterou Payky pro toto zařízení vygeneroval. Můžete ji přejmenovat a zapnout synchronizaci teď, nebo později v Nastavení.",
+  "onboarding.accountChoice.description":
+    "Vytvořte nový účet pro toto zařízení nebo obnovte účet, který už používáte.",
+  "onboarding.accountChoice.new.description":
+    "Vygenerujte novou recovery phrase a začněte s prázdným účtem.",
+  "onboarding.accountChoice.new.title": "Založit nový účet",
+  "onboarding.accountChoice.restore.description":
+    "Pomocí recovery phrase otevřete data svého existujícího účtu.",
+  "onboarding.accountChoice.restore.title": "Obnovit existující účet",
+  "onboarding.accountChoice.title": "Výběr účtu",
   "onboarding.account.name.description":
     "Zobrazuje se v seznamu účtů při přepínání identit.",
   "onboarding.account.name.error.required": "Zadejte název účtu.",
@@ -233,6 +247,10 @@ export const cs = {
   "onboarding.payments.iban.title": "IBAN",
   "onboarding.payments.title": "Platební metody",
   "onboarding.progress": "Krok",
+  "onboarding.restore.action": "Obnovit účet",
+  "onboarding.restore.description":
+    "Zadejte BIP39 recovery phrase účtu, který chcete obnovit.",
+  "onboarding.restore.title": "Obnovení existujícího účtu",
   "onboarding.title": "Nastavení Payky",
   "paymentHistory.empty.description":
     "Vytvořené platební žádosti se zobrazí tady.",

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -1,6 +1,11 @@
 export const en = {
   "accountRestore.description":
     "Waiting for the account data to sync. This usually takes a few seconds.",
+  "accountRestore.timeout.continue": "Keep waiting",
+  "accountRestore.timeout.description":
+    "No account settings have arrived yet. You can keep waiting or explicitly set up this account as new.",
+  "accountRestore.timeout.setup": "Set up as a new account",
+  "accountRestore.timeout.title": "Still restoring account",
   "accountRestore.title": "Restoring account",
   "activity.amount.btc": "฿145",
   "activity.amount.usd": "$9.00",
@@ -205,6 +210,15 @@ export const en = {
   "nav.settings": "Settings",
   "onboarding.account.description":
     "Review the identity Payky generated for this device. You can rename it and turn on sync now or later in Settings.",
+  "onboarding.accountChoice.description":
+    "Create a new account for this device or restore one you already use.",
+  "onboarding.accountChoice.new.description":
+    "Generate a new recovery phrase and start with an empty account.",
+  "onboarding.accountChoice.new.title": "Create a new account",
+  "onboarding.accountChoice.restore.description":
+    "Use a recovery phrase to open your existing account data.",
+  "onboarding.accountChoice.restore.title": "Restore an existing account",
+  "onboarding.accountChoice.title": "Choose an account",
   "onboarding.account.name.description":
     "Shown in the accounts list when switching identities.",
   "onboarding.account.name.error.required": "Enter an account name.",
@@ -231,6 +245,10 @@ export const en = {
   "onboarding.payments.iban.title": "IBAN",
   "onboarding.payments.title": "Payment methods",
   "onboarding.progress": "Step",
+  "onboarding.restore.action": "Restore account",
+  "onboarding.restore.description":
+    "Enter the BIP39 recovery phrase for the account you want to restore.",
+  "onboarding.restore.title": "Restore existing account",
   "onboarding.title": "Set up Payky",
   "paymentHistory.empty.description":
     "Created payment requests will appear here.",

--- a/src/i18n/sk.ts
+++ b/src/i18n/sk.ts
@@ -3,6 +3,11 @@ import type { TranslationKey } from "@/i18n/en.ts"
 export const sk = {
   "accountRestore.description":
     "Čakáme na synchronizáciu údajov účtu. Zvyčajne to trvá pár sekúnd.",
+  "accountRestore.timeout.continue": "Čakať ďalej",
+  "accountRestore.timeout.description":
+    "Nastavenia účtu zatiaľ nedorazili. Môžete ďalej čakať alebo tento účet výslovne nastaviť ako nový.",
+  "accountRestore.timeout.setup": "Nastaviť ako nový účet",
+  "accountRestore.timeout.title": "Obnova účtu stále prebieha",
   "accountRestore.title": "Obnovovanie účtu",
   "activity.amount.btc": "฿145",
   "activity.amount.usd": "$9.00",
@@ -207,6 +212,15 @@ export const sk = {
   "nav.settings": "Nastavenia",
   "onboarding.account.description":
     "Skontrolujte identitu, ktorú Payky pre toto zariadenie vygeneroval. Môžete ju premenovať a zapnúť synchronizáciu teraz, alebo neskôr v Nastaveniach.",
+  "onboarding.accountChoice.description":
+    "Vytvorte nový účet pre toto zariadenie alebo obnovte účet, ktorý už používate.",
+  "onboarding.accountChoice.new.description":
+    "Vygenerujte novú recovery phrase a začnite s prázdnym účtom.",
+  "onboarding.accountChoice.new.title": "Vytvoriť nový účet",
+  "onboarding.accountChoice.restore.description":
+    "Pomocou recovery phrase otvorte dáta svojho existujúceho účtu.",
+  "onboarding.accountChoice.restore.title": "Obnoviť existujúci účet",
+  "onboarding.accountChoice.title": "Výber účtu",
   "onboarding.account.name.description":
     "Zobrazuje sa v zozname účtov pri prepínaní identít.",
   "onboarding.account.name.error.required": "Zadajte názov účtu.",
@@ -234,6 +248,10 @@ export const sk = {
   "onboarding.payments.iban.title": "IBAN",
   "onboarding.payments.title": "Platobné metódy",
   "onboarding.progress": "Krok",
+  "onboarding.restore.action": "Obnoviť účet",
+  "onboarding.restore.description":
+    "Zadajte BIP39 recovery phrase účtu, ktorý chcete obnoviť.",
+  "onboarding.restore.title": "Obnovenie existujúceho účtu",
   "onboarding.title": "Nastavenie Payky",
   "paymentHistory.empty.description":
     "Vytvorené platobné žiadosti sa zobrazia tu.",

--- a/src/routes/_terminal.settings.accounts.tsx
+++ b/src/routes/_terminal.settings.accounts.tsx
@@ -1,4 +1,3 @@
-import { Mnemonic } from "@evolu/common"
 import { createFileRoute, useNavigate } from "@tanstack/react-router"
 import { useAtomValue, useSetAtom } from "jotai"
 import { Check, KeyRound, Plus, Trash2, UserRound } from "lucide-react"
@@ -34,8 +33,7 @@ import {
   selectAccount,
 } from "@/core/evolu/device-account.ts"
 import type { AccountId } from "@/core/evolu/device-client.ts"
-import { normalizeMnemonic } from "@/core/modules/account/account-utils.ts"
-import { useSettingsForm } from "@/features/settings/use-settings-form.ts"
+import { useRestoreAccount } from "@/features/account/use-restore-account.ts"
 import { useDeviceEvoluQuery } from "@/hooks/use-device-evolu-query.ts"
 import { useTranslation } from "@/hooks/use-translation.ts"
 
@@ -55,7 +53,6 @@ function AccountsSettingsPage() {
   const activeAccount = useAtomValue(accountAtom)
   const setEvoluCounter = useSetAtom(evoluCounterAtom)
   const { data: accounts } = useDeviceEvoluQuery(accountListQuery)
-  const [mnemonic, setMnemonic] = useState("")
   const [pendingAccountId, setPendingAccountId] = useState<AccountId | null>(
     null
   )
@@ -63,7 +60,14 @@ function AccountsSettingsPage() {
     null
   )
   const [creating, setCreating] = useState(false)
-  const { pending: restoring, error, setError, submit } = useSettingsForm()
+  const {
+    mnemonic,
+    pending: restoring,
+    error,
+    clearError,
+    setMnemonic,
+    restore,
+  } = useRestoreAccount()
   const mnemonicInputId = useId()
 
   const dateFormatter = new Intl.DateTimeFormat(language, {
@@ -103,7 +107,7 @@ function AccountsSettingsPage() {
   }
 
   const createNewAccount = async () => {
-    setError(null)
+    clearError()
     setCreating(true)
     try {
       await createOrSelectAccount(deviceEvolu, createAccountMnemonic())
@@ -114,27 +118,11 @@ function AccountsSettingsPage() {
   }
 
   const restoreAccount = async () => {
-    setError(null)
+    const restored = await restore()
 
-    const normalizedMnemonic = normalizeMnemonic(mnemonic)
-
-    if (normalizedMnemonic === "") {
-      setError("settings.accounts.restore.mnemonic.required")
-      return
-    }
-
-    const mnemonicResult = Mnemonic.from(normalizedMnemonic)
-
-    if (!mnemonicResult.ok) {
-      setError("settings.accounts.restore.mnemonic.invalid")
-      return
-    }
-
-    await submit(async () => {
-      await createOrSelectAccount(deviceEvolu, mnemonicResult.value)
-      reloadAppAccount()
+    if (restored) {
       await navigate({ to: "/restore-account" })
-    })
+    }
   }
 
   const pending =
@@ -273,7 +261,6 @@ function AccountsSettingsPage() {
                     )}
                     onChange={(event) => {
                       setMnemonic(event.currentTarget.value)
-                      setError(null)
                     }}
                   />
                   <FieldDescription>

--- a/src/routes/onboarding.tsx
+++ b/src/routes/onboarding.tsx
@@ -7,14 +7,17 @@ import {
   Check,
   ChevronLeft,
   ChevronRight,
+  KeyRound,
   Landmark,
   Languages,
+  Plus,
 } from "lucide-react"
 import { useEffect, useId, useState } from "react"
 
 import { accountAtom } from "@/atoms/account.ts"
 import { deviceEvoluAtom } from "@/atoms/device-evolu.ts"
 import { evoluCounterAtom } from "@/atoms/evolu-counter.ts"
+import { PasswordTextarea } from "@/components/password-textarea.tsx"
 import { PhoneViewport } from "@/components/phone-viewport.tsx"
 import { Button } from "@/components/ui/button.tsx"
 import {
@@ -51,12 +54,14 @@ import {
   type FiatCurrency as FiatCurrencyType,
 } from "@/core/modules/shared/schema.ts"
 import { runMutationWithCompletion } from "@/core/modules/shared/utils.ts"
+import { useRestoreAccount } from "@/features/account/use-restore-account.ts"
 import {
+  getOnboardingSteps,
   initialOnboardingFormState,
+  type OnboardingAccountType,
   type OnboardingPaymentMethod,
   type OnboardingStep,
   onboardingFormAtom,
-  onboardingSteps,
 } from "@/features/onboarding/onboarding-form-state.ts"
 import { languageOptions } from "@/features/settings/language-options.ts"
 import { OptionToggleGroup } from "@/features/settings/option-toggle-group.tsx"
@@ -87,6 +92,13 @@ interface CurrencyOption {
   readonly value: FiatCurrencyType
   readonly label: TranslationKey
   readonly description: TranslationKey
+}
+
+interface AccountTypeOption {
+  readonly value: OnboardingAccountType
+  readonly label: TranslationKey
+  readonly description: TranslationKey
+  readonly icon: typeof Plus
 }
 
 const paymentMethodOptions: ReadonlyArray<PaymentMethodOption> = [
@@ -128,7 +140,25 @@ const currencyOptions: ReadonlyArray<CurrencyOption> = [
   },
 ]
 
-const getStepIndex = (step: OnboardingStep) => onboardingSteps.indexOf(step)
+const accountTypeOptions: ReadonlyArray<AccountTypeOption> = [
+  {
+    value: "new",
+    label: "onboarding.accountChoice.new.title",
+    description: "onboarding.accountChoice.new.description",
+    icon: Plus,
+  },
+  {
+    value: "restore",
+    label: "onboarding.accountChoice.restore.title",
+    description: "onboarding.accountChoice.restore.description",
+    icon: KeyRound,
+  },
+]
+
+const getStepIndex = (
+  step: OnboardingStep,
+  onboardingSteps: ReadonlyArray<OnboardingStep>
+) => onboardingSteps.indexOf(step)
 
 const getDefaultCurrencyForLanguage = (
   languageValue: Language
@@ -154,10 +184,24 @@ function OnboardingPage() {
   const [settings] = settingsData
   const [form, setForm] = useAtom(onboardingFormAtom)
   const [ibanError, setIbanError] = useState<TranslationKey | null>(null)
-  const [pending, setPending] = useState(false)
+  const [finishing, setFinishing] = useState(false)
+  const {
+    mnemonic,
+    pending: restoring,
+    error: restoreError,
+    setMnemonic,
+    restore,
+  } = useRestoreAccount()
   const ibanInputId = useId()
 
-  const { step, iban, paymentMethods: selectedPaymentMethods } = form
+  const {
+    step,
+    accountType,
+    iban,
+    paymentMethods: selectedPaymentMethods,
+  } = form
+  const onboardingSteps = getOnboardingSteps(accountType)
+  const pending = finishing || restoring
   const selectedCurrency =
     form.currency ?? getDefaultCurrencyForLanguage(language)
 
@@ -170,7 +214,7 @@ function OnboardingPage() {
     }
   }, [navigate, settings])
 
-  const stepIndex = getStepIndex(step)
+  const stepIndex = getStepIndex(step, onboardingSteps)
   const canGoBack = stepIndex > 0 && !pending
 
   const goNext = () => {
@@ -220,7 +264,7 @@ function OnboardingPage() {
       return
     }
 
-    setPending(true)
+    setFinishing(true)
     try {
       setLocale(getDeviceLocaleForLanguage(language))
 
@@ -259,8 +303,19 @@ function OnboardingPage() {
       setForm(initialOnboardingFormState)
       await navigate({ to: "/", replace: true })
     } finally {
-      setPending(false)
+      setFinishing(false)
     }
+  }
+
+  const restoreExistingAccount = async () => {
+    const restored = await restore()
+
+    if (!restored) {
+      return
+    }
+
+    setForm(initialOnboardingFormState)
+    await navigate({ to: "/restore-account" })
   }
 
   return (
@@ -277,7 +332,7 @@ function OnboardingPage() {
                 {t("onboarding.title")}
               </h1>
             </div>
-            <StepDots activeStep={step} />
+            <StepDots activeStep={step} onboardingSteps={onboardingSteps} />
           </div>
 
           <Card>
@@ -292,6 +347,19 @@ function OnboardingPage() {
                   setForm((current) => ({
                     ...current,
                     currency: getDefaultCurrencyForLanguage(nextLanguage),
+                  }))
+                }}
+              />
+            ) : null}
+
+            {step === "accountChoice" ? (
+              <AccountChoiceStep
+                accountType={accountType}
+                pending={pending}
+                onSelect={(nextAccountType) => {
+                  setForm((current) => ({
+                    ...current,
+                    accountType: nextAccountType,
                   }))
                 }}
               />
@@ -324,32 +392,52 @@ function OnboardingPage() {
 
             {step === "account" ? <AccountStep /> : null}
 
-            <CardFooter className="flex items-center justify-between gap-3">
-              <Button
-                type="button"
-                variant="outline"
-                disabled={!canGoBack}
-                onClick={goBack}
-              >
-                <ChevronLeft data-icon="inline-start" />
-                {t("onboarding.back")}
-              </Button>
-              {step === "account" ? (
+            {step === "restore" ? (
+              <RestoreAccountStep
+                error={restoreError}
+                mnemonic={mnemonic}
+                pending={pending}
+                onBack={goBack}
+                onMnemonicChange={setMnemonic}
+                onRestore={() => {
+                  void restoreExistingAccount()
+                }}
+              />
+            ) : (
+              <CardFooter className="flex items-center justify-between gap-3">
                 <Button
                   type="button"
-                  disabled={pending}
-                  onClick={finishOnboarding}
+                  variant="outline"
+                  disabled={!canGoBack}
+                  onClick={goBack}
                 >
-                  <Check data-icon="inline-start" />
-                  {t("onboarding.finish")}
+                  <ChevronLeft data-icon="inline-start" />
+                  {t("onboarding.back")}
                 </Button>
-              ) : (
-                <Button type="button" disabled={pending} onClick={goNext}>
-                  {t("onboarding.next")}
-                  <ChevronRight data-icon="inline-end" />
-                </Button>
-              )}
-            </CardFooter>
+                {step === "account" ? (
+                  <Button
+                    type="button"
+                    disabled={pending}
+                    onClick={finishOnboarding}
+                  >
+                    <Check data-icon="inline-start" />
+                    {t("onboarding.finish")}
+                  </Button>
+                ) : (
+                  <Button
+                    type="button"
+                    disabled={
+                      pending ||
+                      (step === "accountChoice" && accountType === null)
+                    }
+                    onClick={goNext}
+                  >
+                    {t("onboarding.next")}
+                    <ChevronRight data-icon="inline-end" />
+                  </Button>
+                )}
+              </CardFooter>
+            )}
           </Card>
         </div>
       </PhoneViewport>
@@ -389,6 +477,122 @@ function LanguageStep({
           onChange={onSelect}
         />
       </CardContent>
+    </>
+  )
+}
+
+function AccountChoiceStep({
+  accountType,
+  pending,
+  onSelect,
+}: {
+  readonly accountType: OnboardingAccountType | null
+  readonly pending: boolean
+  readonly onSelect: (accountType: OnboardingAccountType) => void
+}) {
+  const { t } = useTranslation()
+
+  return (
+    <>
+      <CardHeader>
+        <CardTitle>{t("onboarding.accountChoice.title")}</CardTitle>
+        <CardDescription>
+          {t("onboarding.accountChoice.description")}
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <OptionToggleGroup
+          value={accountType}
+          options={accountTypeOptions.map((option) => ({
+            value: option.value,
+            icon: option.icon,
+            title: t(option.label),
+            description: t(option.description),
+          }))}
+          disabled={pending}
+          onChange={onSelect}
+        />
+      </CardContent>
+    </>
+  )
+}
+
+function RestoreAccountStep({
+  error,
+  mnemonic,
+  pending,
+  onBack,
+  onMnemonicChange,
+  onRestore,
+}: {
+  readonly error: TranslationKey | null
+  readonly mnemonic: string
+  readonly pending: boolean
+  readonly onBack: () => void
+  readonly onMnemonicChange: (mnemonic: string) => void
+  readonly onRestore: () => void
+}) {
+  const { t } = useTranslation()
+  const mnemonicInputId = useId()
+
+  return (
+    <>
+      <CardHeader>
+        <CardTitle>{t("onboarding.restore.title")}</CardTitle>
+        <CardDescription>{t("onboarding.restore.description")}</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <form
+          onSubmit={(event) => {
+            event.preventDefault()
+            onRestore()
+          }}
+        >
+          <FieldGroup>
+            <Field data-invalid={error !== null}>
+              <FieldLabel htmlFor={mnemonicInputId}>
+                {t("settings.accounts.restore.mnemonic.label")}
+              </FieldLabel>
+              <PasswordTextarea
+                id={mnemonicInputId}
+                value={mnemonic}
+                hideLabel={t("passwordTextarea.hide")}
+                showLabel={t("passwordTextarea.show")}
+                disabled={pending}
+                aria-invalid={error !== null}
+                autoComplete="off"
+                placeholder={t(
+                  "settings.accounts.restore.mnemonic.placeholder"
+                )}
+                onChange={(event) => {
+                  onMnemonicChange(event.currentTarget.value)
+                }}
+              />
+              <FieldDescription>
+                {t("settings.accounts.restore.mnemonic.description")}
+              </FieldDescription>
+              <FieldError>{error ? t(error) : null}</FieldError>
+            </Field>
+          </FieldGroup>
+          <div className="mt-4 flex justify-end">
+            <Button type="submit" disabled={pending}>
+              <KeyRound data-icon="inline-start" />
+              {t("onboarding.restore.action")}
+            </Button>
+          </div>
+        </form>
+      </CardContent>
+      <CardFooter>
+        <Button
+          type="button"
+          variant="outline"
+          disabled={pending}
+          onClick={onBack}
+        >
+          <ChevronLeft data-icon="inline-start" />
+          {t("onboarding.back")}
+        </Button>
+      </CardFooter>
     </>
   )
 }
@@ -593,8 +797,14 @@ function AccountStep() {
   )
 }
 
-function StepDots({ activeStep }: { readonly activeStep: OnboardingStep }) {
-  const activeStepIndex = getStepIndex(activeStep)
+function StepDots({
+  activeStep,
+  onboardingSteps,
+}: {
+  readonly activeStep: OnboardingStep
+  readonly onboardingSteps: ReadonlyArray<OnboardingStep>
+}) {
+  const activeStepIndex = getStepIndex(activeStep, onboardingSteps)
 
   return (
     <div className="flex items-center gap-2" aria-hidden="true">

--- a/src/routes/restore-account.tsx
+++ b/src/routes/restore-account.tsx
@@ -1,8 +1,9 @@
 import { createFileRoute, useNavigate } from "@tanstack/react-router"
 import { LoaderCircleIcon } from "lucide-react"
-import { useEffect } from "react"
+import { useEffect, useState } from "react"
 
 import { PhoneViewport } from "@/components/phone-viewport.tsx"
+import { Button } from "@/components/ui/button.tsx"
 import { settingsQuery } from "@/core/modules/app-settings/app-settings-queries.ts"
 import { useEvoluQuery } from "@/hooks/use-evolu-query.ts"
 import { useTranslation } from "@/hooks/use-translation.ts"
@@ -21,6 +22,7 @@ function RestoreAccountPage() {
   const { t } = useTranslation()
   const { data } = useEvoluQuery(settingsQuery)
   const [settings] = data
+  const [timedOut, setTimedOut] = useState(false)
   const restored = settings !== undefined
 
   useEffect(() => {
@@ -30,18 +32,18 @@ function RestoreAccountPage() {
   }, [navigate, restored])
 
   useEffect(() => {
-    if (restored) {
+    if (restored || timedOut) {
       return
     }
 
     const timeout = setTimeout(() => {
-      void navigate({ to: "/onboarding", replace: true })
+      setTimedOut(true)
     }, syncWaitTimeoutMs)
 
     return () => {
       clearTimeout(timeout)
     }
-  }, [navigate, restored])
+  }, [restored, timedOut])
 
   return (
     <main className="min-h-svh bg-background text-foreground">
@@ -50,16 +52,48 @@ function RestoreAccountPage() {
           className="flex flex-col items-center gap-4 text-center"
           aria-live="polite"
         >
-          <LoaderCircleIcon
-            className="size-8 animate-spin text-muted-foreground"
-            aria-hidden="true"
-          />
-          <h1 className="font-semibold text-2xl leading-tight">
-            {t("accountRestore.title")}
-          </h1>
-          <p className="text-sm text-muted-foreground">
-            {t("accountRestore.description")}
-          </p>
+          {timedOut ? (
+            <>
+              <h1 className="font-semibold text-2xl leading-tight">
+                {t("accountRestore.timeout.title")}
+              </h1>
+              <p className="text-sm text-muted-foreground">
+                {t("accountRestore.timeout.description")}
+              </p>
+              <div className="flex flex-wrap justify-center gap-3">
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={() => {
+                    setTimedOut(false)
+                  }}
+                >
+                  {t("accountRestore.timeout.continue")}
+                </Button>
+                <Button
+                  type="button"
+                  onClick={() => {
+                    void navigate({ to: "/onboarding", replace: true })
+                  }}
+                >
+                  {t("accountRestore.timeout.setup")}
+                </Button>
+              </div>
+            </>
+          ) : (
+            <>
+              <LoaderCircleIcon
+                className="size-8 animate-spin text-muted-foreground"
+                aria-hidden="true"
+              />
+              <h1 className="font-semibold text-2xl leading-tight">
+                {t("accountRestore.title")}
+              </h1>
+              <p className="text-sm text-muted-foreground">
+                {t("accountRestore.description")}
+              </p>
+            </>
+          )}
         </div>
       </PhoneViewport>
     </main>


### PR DESCRIPTION
## Summary
- Adds an account-choice step to onboarding letting the user create a new account or restore an existing one from a recovery phrase
- Extracts mnemonic-restore validation/submission into a shared `useRestoreAccount` hook, reused by both onboarding and Settings > Accounts
- Adds a timeout screen on `/restore-account` offering to keep waiting or set up the account as new when sync doesn't arrive in time

## Test plan
- [ ] Run through onboarding choosing "Create a new account" end to end
- [ ] Run through onboarding choosing "Restore an existing account" with a valid mnemonic
- [ ] Verify invalid/empty mnemonic shows the validation error on both onboarding and Settings > Accounts
- [ ] Verify the `/restore-account` timeout screen appears after 15s and both its actions ("Keep waiting" / "Set up as a new account") work
- [ ] `bun test` for the new `onboarding-form-state.test.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)