### PR TITLE
fix(ci): scope label-triggered workflows to their own label

### DIFF
--- a/.github/workflows/deploy-vercel.yml
+++ b/.github/workflows/deploy-vercel.yml
@@ -23,7 +23,8 @@ jobs:
     if: >-
       (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
       (github.event_name == 'pull_request_target' &&
-      contains(github.event.pull_request.labels.*.name, 'deploy-preview'))
+      ((github.event.action == 'labeled' && github.event.label.name == 'deploy-preview') ||
+      (github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'deploy-preview'))))
     runs-on: ubuntu-latest
     environment:
       name: ${{ github.event_name == 'pull_request_target' && 'test' || 'production' }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -14,7 +14,8 @@ jobs:
     name: Playwright E2E (production build)
     if: >-
       github.event_name == 'workflow_dispatch' ||
-      contains(github.event.pull_request.labels.*.name, 'run-e2e')
+      (github.event.action == 'labeled' && github.event.label.name == 'run-e2e') ||
+      (github.event.action == 'synchronize' && contains(github.event.pull_request.labels.*.name, 'run-e2e'))
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
Adding an unrelated label to a PR that already has run-e2e or deploy-preview re-triggered the e2e/deploy-vercel jobs, since the `labeled`/`synchronize` if-conditions only checked whether the target label was present anywhere in the PR's current label set. Narrow the `labeled` branch to the label actually added by the event.