### PR TITLE
fix(sync): prevent invoice crashes after enabling WebSocket

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -14,7 +14,7 @@
         "@capacitor/haptics": "8.0.2",
         "@capacitor/ios": "8.5.0",
         "@dedalik/use-react": "1.1.2",
-        "@evolu/common": "8.5.0",
+        "@evolu/common": "8.6.1",
         "@evolu/nodejs": "3.0.1",
         "@evolu/react-web": "3.0.1",
         "@evolu/sqlite-wasm": "2.2.4",
@@ -389,7 +389,7 @@
 
     "@esbuild/win32-x64": ["@esbuild/win32-x64@0.28.1", "", { "os": "win32", "cpu": "x64" }, "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A=="],
 
-    "@evolu/common": ["@evolu/common@8.5.0", "", { "dependencies": { "@noble/ciphers": "^2.3.0", "@noble/hashes": "^2.3.0", "@scure/bip39": "^2.3.0", "@standard-schema/spec": "^1.1.0", "kysely": "^0.29.5", "msgpackr": "^2.0.5", "random": "5.5.1" } }, "sha512-Okc+OhSI//NZrSCLP+4i1l8cveYyYGFWqZ/PiSSibkoabszhG0c78j5hUNIoKGDa2mIfOFPFdwDCS1hHg95Wkg=="],
+    "@evolu/common": ["@evolu/common@8.6.1", "", { "dependencies": { "@noble/ciphers": "^2.3.0", "@noble/hashes": "^2.3.0", "@scure/bip39": "^2.3.0", "@standard-schema/spec": "^1.1.0", "kysely": "^0.29.5", "msgpackr": "^2.0.5", "random": "5.5.1" } }, "sha512-dxjhALf9VN+FO36aDGwjuZ0Dt9T6miORLXlX9pI2YjnWvpZ4W7GnB25bNk3sPpJNBy3bDY6fRf+Hl6JXKVnotQ=="],
 
     "@evolu/nodejs": ["@evolu/nodejs@3.0.1", "", { "dependencies": { "better-sqlite3": "^12.11.1", "ws": "^8.19.0" }, "peerDependencies": { "@evolu/common": "^8.0.0", "vite": ">=8.0.0", "webpack": ">=5.108.4" }, "optionalPeers": ["vite", "webpack"] }, "sha512-tCTTRKpJ4BFKpF2TeIoYydVvIGHBsW3DepulYwZPIeBGGACvkZ1wV/BT8skde0TOTYmR5yoPhEi3WrCD8fThwg=="],
 

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "@capacitor/haptics": "8.0.2",
     "@capacitor/ios": "8.5.0",
     "@dedalik/use-react": "1.1.2",
-    "@evolu/common": "8.5.0",
+    "@evolu/common": "8.6.1",
     "@evolu/nodejs": "3.0.1",
     "@evolu/react-web": "3.0.1",
     "@evolu/sqlite-wasm": "2.2.4",


### PR DESCRIPTION
Enabling the WebSocket transport after onboarding without sync could leave the app blank when confirming an invoice's tip. The console reported `Error: Expected value to be non-nullable.`

The cause was `@evolu/common@8.5.0`'s `encodeAndEncryptDbChange`. `readDbChange` reconstructs pending database changes for the relay, then this encoder called `assertNonNullable(value)` for every column. Payky correctly writes explicit `null` values for optional payment fields, including `billId`, `tableId`, `canceledAt`, and `expiresAt`. The assertion rejected those values before the existing SQLite null encoder could serialize them. Syncing earlier nullable writes can trigger the same error as soon as the transport is activated; choosing a tip then creates the payment that exposes the broken flow.

Pin `@evolu/common` to 8.6.1, the first release containing [the upstream fix](https://github.com/evoluhq/evolu/commit/9e71ebdce3d783a0f0241ae6eb1debd2ece61997). It replaces `assertNonNullable` with `assertNotUndefined`, allowing valid SQLite nulls through the existing wire format while still rejecting undefined. No schema migration or removal of stored nulls is needed.

Validation:

- Reproduced the console stack and blank payment page on 8.5.0. Verified that nullable values round-trip through the sync encoder after the upgrade.
- `bun run check`: lint, TypeScript, and unit tests pass.
- `bun run build` passes.
- All four payment-tip Playwright tests pass against both the HTTPS dev server and the production build via `bun run test:e2e:preview e2e/payment-tip.spec.ts --reporter=list`.
- Fresh browser account, real onboarding with sync disabled, Settings → Security & Sync → Activate WebSocket, then a 10% tip: the payment opens without console or page errors. A second isolated browser restores the account through the real relay, receives that payment, marks it paid, and syncs the result back to the first browser. The paid state persists after reload. This two-device check passed against both development and production preview, with Chromium configured to accept the local self-signed HTTPS certificate.
